### PR TITLE
NP-15526-skip-invalid-issn, issn and isbn are implemented

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,10 +63,11 @@ dependencies {
     implementation group: 'com.github.bibsysdev', name: 'logutils', version: '1.25.7'
 
     implementation group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '4.0.0'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.3'
 
     implementation group: 'org.apache.jena', name: 'jena-core', version: '4.6.1'
     implementation group: 'org.apache.jena', name: 'jena-arq', version: '4.6.1'
+    implementation group: 'commons-validator', name: 'commons-validator', version: '1.7'
+
 }
 
 compileJava {

--- a/src/main/java/no/sikt/nva/DublinCoreParser.java
+++ b/src/main/java/no/sikt/nva/DublinCoreParser.java
@@ -36,6 +36,7 @@ public class DublinCoreParser {
     private static Publication extractPublication(DublinCore dublinCore) {
         var publication = new Publication();
         publication.setIssn(extractIssn(dublinCore));
+        publication.setIsbn(extractIsbn(dublinCore));
         publication.setJournal(extractJournal(dublinCore));
         publication.setPublisher(extractPublisher(dublinCore));
 
@@ -73,9 +74,15 @@ public class DublinCoreParser {
                    .findAny().orElse(new DcValue()).getValue();
     }
 
-    private static String extractIssn(DublinCore dublinCore) {
+    public static String extractIssn(DublinCore dublinCore) {
         return dublinCore.getDcValues().stream()
                    .filter(DcValue::isIssnValue)
+                   .findAny().orElse(new DcValue()).getValue();
+    }
+
+    public static String extractIsbn(DublinCore dublinCore) {
+        return dublinCore.getDcValues().stream()
+                   .filter(DcValue::isIsbnValue)
                    .findAny().orElse(new DcValue()).getValue();
     }
 }

--- a/src/main/java/no/sikt/nva/DublinCoreParser.java
+++ b/src/main/java/no/sikt/nva/DublinCoreParser.java
@@ -53,7 +53,7 @@ public class DublinCoreParser {
 
     private static void logUnscrapedDcValue(DcValue dcValue, Record record) {
         logger.info(String.format(FIELD_WAS_NOT_SCRAPED_IN_LOCATION_LOG_MESSAGE,
-                                  dcValue.getValue(),
+                                  dcValue.toXmlString(),
                                   record.getOriginInformation()));
     }
 

--- a/src/main/java/no/sikt/nva/DublinCoreValidator.java
+++ b/src/main/java/no/sikt/nva/DublinCoreValidator.java
@@ -4,17 +4,21 @@ import java.util.ArrayList;
 import java.util.List;
 import no.sikt.nva.model.dublincore.DcValue;
 import no.sikt.nva.model.dublincore.DublinCore;
+import org.apache.commons.validator.routines.ISBNValidator;
+import org.apache.commons.validator.routines.ISSNValidator;
 
 public final class DublinCoreValidator {
-    
-    public enum Problem {
-        CRISTIN_ID_PRESENT
-    }
 
-    public static List<Problem>  getDublinCoreErrors(DublinCore dublinCore) {
+    public static List<Problem> getDublinCoreErrors(DublinCore dublinCore) {
         var problems = new ArrayList<Problem>();
         if (hasCristinIdentifier(dublinCore)) {
             problems.add(Problem.CRISTIN_ID_PRESENT);
+        }
+        if (!isValidIssn(dublinCore)) {
+            problems.add(Problem.INVALID_ISSN);
+        }
+        if (!isValidIsbn(dublinCore)) {
+            problems.add(Problem.INVALID_ISBN);
         }
         return problems;
     }
@@ -22,5 +26,39 @@ public final class DublinCoreValidator {
     private static boolean hasCristinIdentifier(DublinCore dublinCore) {
         return dublinCore.getDcValues().stream()
                    .anyMatch(DcValue::isCristinDcValue);
+    }
+
+    private static boolean isValidIssn(DublinCore dublinCore) {
+        if (hasIssn(dublinCore)) {
+            var issn = DublinCoreParser.extractIssn(dublinCore);
+            ISSNValidator validator = new ISSNValidator();
+            return validator.isValid(issn);
+        }
+        return true;
+    }
+
+    private static boolean isValidIsbn(DublinCore dublinCore) {
+        if (hasIsbn(dublinCore)) {
+            var isbn = DublinCoreParser.extractIsbn(dublinCore);
+            ISBNValidator validator = new ISBNValidator();
+            return validator.isValid(isbn);
+        }
+        return true;
+    }
+
+    private static boolean hasIssn(DublinCore dublinCore) {
+        return dublinCore.getDcValues().stream()
+                   .anyMatch(DcValue::isIssnValue);
+    }
+
+    private static boolean hasIsbn(DublinCore dublinCore) {
+        return dublinCore.getDcValues().stream()
+                   .anyMatch(DcValue::isIsbnValue);
+    }
+
+    public enum Problem {
+        CRISTIN_ID_PRESENT,
+        INVALID_ISSN,
+        INVALID_ISBN
     }
 }

--- a/src/main/java/no/sikt/nva/DublinCoreValidator.java
+++ b/src/main/java/no/sikt/nva/DublinCoreValidator.java
@@ -14,10 +14,10 @@ public final class DublinCoreValidator {
         if (hasCristinIdentifier(dublinCore)) {
             problems.add(Problem.CRISTIN_ID_PRESENT);
         }
-        if (!isValidIssn(dublinCore)) {
+        if (!presentIssnIsValid(dublinCore)) {
             problems.add(Problem.INVALID_ISSN);
         }
-        if (!isValidIsbn(dublinCore)) {
+        if (!presentIsbnIsValid(dublinCore)) {
             problems.add(Problem.INVALID_ISBN);
         }
         return problems;
@@ -28,7 +28,7 @@ public final class DublinCoreValidator {
                    .anyMatch(DcValue::isCristinDcValue);
     }
 
-    private static boolean isValidIssn(DublinCore dublinCore) {
+    private static boolean presentIssnIsValid(DublinCore dublinCore) {
         if (hasIssn(dublinCore)) {
             var issn = DublinCoreParser.extractIssn(dublinCore);
             ISSNValidator validator = new ISSNValidator();
@@ -37,7 +37,7 @@ public final class DublinCoreValidator {
         return true;
     }
 
-    private static boolean isValidIsbn(DublinCore dublinCore) {
+    private static boolean presentIsbnIsValid(DublinCore dublinCore) {
         if (hasIsbn(dublinCore)) {
             var isbn = DublinCoreParser.extractIsbn(dublinCore);
             ISBNValidator validator = new ISBNValidator();

--- a/src/main/java/no/sikt/nva/model/dublincore/DcValue.java
+++ b/src/main/java/no/sikt/nva/model/dublincore/DcValue.java
@@ -60,6 +60,10 @@ public class DcValue {
         return Element.IDENTIFIER.equals(this.element) && Qualifier.ISSN.equals(this.qualifier);
     }
 
+    public boolean isIsbnValue() {
+        return Element.IDENTIFIER.equals(this.element) && Qualifier.ISBN.equals(this.qualifier);
+    }
+
     public boolean isCristinDcValue() {
         return Element.IDENTIFIER.equals(this.element) && Qualifier.CRISTIN.equals(this.qualifier);
     }

--- a/src/main/java/no/sikt/nva/model/dublincore/Qualifier.java
+++ b/src/main/java/no/sikt/nva/model/dublincore/Qualifier.java
@@ -24,6 +24,9 @@ public enum Qualifier {
     @XmlEnumValue("issn")
     ISSN("issn"),
 
+    @XmlEnumValue("isbn")
+    ISBN("isbn"),
+
     @XmlEnumValue("journal")
     JOURNAL("journal"),
 

--- a/src/main/java/no/sikt/nva/model/publisher/Publication.java
+++ b/src/main/java/no/sikt/nva/model/publisher/Publication.java
@@ -8,12 +8,15 @@ public class Publication {
 
     private String journal;
     private String issn;
+    private String isbn;
     private String publisher;
+
+
 
     @JacocoGenerated
     @Override
     public int hashCode() {
-        return Objects.hash(journal, issn, publisher);
+        return Objects.hash(journal, issn, isbn, publisher);
     }
 
     @JacocoGenerated
@@ -28,7 +31,8 @@ public class Publication {
         Publication publication = (Publication) o;
         return Objects.equals(journal, publication.journal)
                && Objects.equals(issn, publication.issn)
-               && Objects.equals(publisher, publication.publisher);
+               && Objects.equals(publisher, publication.publisher)
+               && Objects.equals(isbn, publication.isbn);
     }
 
     @JacocoGenerated
@@ -49,6 +53,16 @@ public class Publication {
 
     public void setIssn(String issn) {
         this.issn = issn;
+    }
+
+    @JacocoGenerated
+    @JsonProperty("isbn")
+    public String getIsbn() {
+        return isbn;
+    }
+
+    public void setIsbn(String isbn) {
+        this.isbn = isbn;
     }
 
     @JacocoGenerated

--- a/src/test/java/no/sikt/nva/BrageMigrationCommandTest.java
+++ b/src/test/java/no/sikt/nva/BrageMigrationCommandTest.java
@@ -42,6 +42,7 @@ public class BrageMigrationCommandTest {
         var appender = LogUtils.getTestingAppenderForRootLogger();
         var arguments = new String[]{"-c", "nve", "-z", "testinput.zip"};
         SystemLambda.catchSystemExit(() -> BrageMigrationCommand.main(arguments));
+        var messages = appender.getMessages();
         assertThat(appender.getMessages(), containsString(NO_LICENSE_LOGG_MESSAGE));
     }
 

--- a/src/test/java/no/sikt/nva/BrageMigrationCommandTest.java
+++ b/src/test/java/no/sikt/nva/BrageMigrationCommandTest.java
@@ -1,6 +1,8 @@
 package no.sikt.nva;
 
 import static no.sikt.nva.DublinCoreValidator.Problem.CRISTIN_ID_PRESENT;
+import static no.sikt.nva.DublinCoreValidator.Problem.INVALID_ISBN;
+import static no.sikt.nva.DublinCoreValidator.Problem.INVALID_ISSN;
 import static no.sikt.nva.HandleScraper.COULD_NOT_READ_HANDLE_FILE_EXCEPTION_MESSAGE;
 import static no.sikt.nva.HandleScraper.ERROR_MESSAGE_NO_HANDLE_IN_DUBLIN_CORE;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -54,9 +56,25 @@ public class BrageMigrationCommandTest {
     @Test
     void shouldProcessAndLogFileWithCristinId() throws Exception {
         var appender = LogUtils.getTestingAppenderForRootLogger();
-        var arguments = new String[]{"-c", "nve", "-z", "inputWithCristinId.zip"};
+        var arguments = new String[]{"-c", "nve", "-z", "invalidFileInput.zip"};
         SystemLambda.catchSystemExit(() -> BrageMigrationCommand.main(arguments));
         assertThat(appender.getMessages(), containsString(String.valueOf(CRISTIN_ID_PRESENT)));
+    }
+
+    @Test
+    void shouldProcessAndLogFileWithInvalidIssn() throws Exception {
+        var appender = LogUtils.getTestingAppenderForRootLogger();
+        var arguments = new String[]{"-c", "nve", "-z", "invalidFileInput.zip"};
+        SystemLambda.catchSystemExit(() -> BrageMigrationCommand.main(arguments));
+        assertThat(appender.getMessages(), containsString(String.valueOf(INVALID_ISSN)));
+    }
+
+    @Test
+    void shouldProcessAndLogFileWithInvalidIsbn() throws Exception {
+        var appender = LogUtils.getTestingAppenderForRootLogger();
+        var arguments = new String[]{"-c", "nve", "-z", "invalidFileInput.zip"};
+        SystemLambda.catchSystemExit(() -> BrageMigrationCommand.main(arguments));
+        assertThat(appender.getMessages(), containsString(String.valueOf(INVALID_ISBN)));
     }
 
     @Test

--- a/src/test/java/no/sikt/nva/DublinCoreParserTest.java
+++ b/src/test/java/no/sikt/nva/DublinCoreParserTest.java
@@ -13,13 +13,15 @@ import org.junit.jupiter.api.Test;
 
 public class DublinCoreParserTest {
 
-    public static final String CRISTIN_DUBLIN_CORE = "src/test/resources/dublin_core_with_cristin_identifier.xml";
+    public static final String INVALID_DUBLIN_CORE = "src/test/resources/invalid_dublin_core.xml";
+
+    public static final String VALID_DUBLIN_CORE = "src/test/resources/valid_dublin_core.xml";
 
     @Test
     void shouldConvertFilesWithValidFields() {
         var expectedRecord = createTestRecord();
         var actualRecord = new Record();
-        var dublinCore = DublinCoreFactory.createDublinCoreFromXml(new File("src/test/resources/dublin_core.xml"),
+        var dublinCore = DublinCoreFactory.createDublinCoreFromXml(new File(VALID_DUBLIN_CORE),
                                                                    actualRecord.getOriginInformation());
        DublinCoreParser.validateAndParseDublinCore(dublinCore, actualRecord);
 
@@ -30,7 +32,7 @@ public class DublinCoreParserTest {
     void shouldReturnExceptionIfResourceIsInCristin() {
         var record = new Record();
         var dublinCore = DublinCoreFactory.createDublinCoreFromXml(new File(
-            CRISTIN_DUBLIN_CORE), record.getOriginInformation());
+            INVALID_DUBLIN_CORE), record.getOriginInformation());
         assertThrows(DublinCoreException.class, () ->
                                                     DublinCoreParser.validateAndParseDublinCore(dublinCore, record));
     }

--- a/src/test/java/no/sikt/nva/DublinCoreValidatorTest.java
+++ b/src/test/java/no/sikt/nva/DublinCoreValidatorTest.java
@@ -1,0 +1,31 @@
+package no.sikt.nva;
+
+import static no.sikt.nva.DublinCoreParserTest.INVALID_DUBLIN_CORE;
+import static no.sikt.nva.DublinCoreParserTest.VALID_DUBLIN_CORE;
+import static no.sikt.nva.DublinCoreValidator.Problem.INVALID_ISBN;
+import static no.sikt.nva.DublinCoreValidator.Problem.INVALID_ISSN;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+import java.io.File;
+import org.junit.jupiter.api.Test;
+
+public class DublinCoreValidatorTest {
+
+    @Test
+    void shouldReturnEmptyProblemListWhenIssnAndIsbnAreValid() {
+        var dublinCore = DublinCoreFactory.createDublinCoreFromXml(new File(
+            VALID_DUBLIN_CORE), "someOrigin");
+        var actualProblemsList = DublinCoreValidator.getDublinCoreErrors(dublinCore);
+        assertThat(actualProblemsList, not(contains(INVALID_ISSN, INVALID_ISBN)));
+    }
+
+    @Test
+    void shouldReturnProblemListContainingInvalidIssnAndInvalidIsbnMessage() {
+        var dublinCore = DublinCoreFactory.createDublinCoreFromXml(new File(
+            INVALID_DUBLIN_CORE), "someOrigin");
+        var actualProblemsList = DublinCoreValidator.getDublinCoreErrors(dublinCore);
+        assertThat(actualProblemsList, hasItems(INVALID_ISSN, INVALID_ISBN));
+    }
+}

--- a/src/test/java/no/sikt/nva/DublinCoreValidatorTest.java
+++ b/src/test/java/no/sikt/nva/DublinCoreValidatorTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 public class DublinCoreValidatorTest {
 
     @Test
-    void shouldReturnEmptyProblemListWhenIssnAndIsbnAreValid() {
+    void validIssnAndIsbnDoesNotAppendProblemsToProblemList() {
         var dublinCore = DublinCoreFactory.createDublinCoreFromXml(new File(
             VALID_DUBLIN_CORE), "someOrigin");
         var actualProblemsList = DublinCoreValidator.getDublinCoreErrors(dublinCore);

--- a/src/test/resources/invalid_dublin_core.xml
+++ b/src/test/resources/invalid_dublin_core.xml
@@ -6,9 +6,10 @@
   <dcvalue element="date" qualifier="accessioned">2020-10-22T06:06:39Z</dcvalue>
   <dcvalue element="date" qualifier="available">2020-10-22T06:06:39Z</dcvalue>
   <dcvalue element="date" qualifier="issued">2020</dcvalue>
-  <dcvalue element="identifier" qualifier="isbn">978-82-502-0583-3</dcvalue>
+  <dcvalue element="identifier" qualifier="issn">1501-282</dcvalue>
+  <dcvalue element="identifier" qualifier="isbn">978-82-50205833</dcvalue>
+  <dcvalue element="identifier" qualifier="cristin">239832498752492</dcvalue>
   <dcvalue element="identifier" qualifier="uri">https:&#x2F;&#x2F;hdl.handle.net&#x2F;12&#x2F;3567</dcvalue>
-  <dcvalue element="identifier" qualifier="issn">2345-2344-5567</dcvalue>
   <dcvalue element="description" qualifier="abstract" language="en_US">Gurba&#x20;Gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;(øæsdfadfåp)</dcvalue>
   <dcvalue element="description" qualifier="provenance" language="en">Gurba&#x20;Gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;(øæsdfadfåp)</dcvalue>
   <dcvalue element="language" qualifier="iso" language="en_US">nob</dcvalue>

--- a/src/test/resources/valid_dublin_core.xml
+++ b/src/test/resources/valid_dublin_core.xml
@@ -7,8 +7,8 @@
   <dcvalue element="date" qualifier="available">2020-10-22T06:06:39Z</dcvalue>
   <dcvalue element="date" qualifier="issued">2020</dcvalue>
   <dcvalue element="identifier" qualifier="isbn">978-82-502-0583-3</dcvalue>
-  <dcvalue element="identifier" qualifier="cristin">239832498752492</dcvalue>
   <dcvalue element="identifier" qualifier="uri">https:&#x2F;&#x2F;hdl.handle.net&#x2F;12&#x2F;3567</dcvalue>
+  <dcvalue element="identifier" qualifier="issn">1501-2832</dcvalue>
   <dcvalue element="description" qualifier="abstract" language="en_US">Gurba&#x20;Gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;(øæsdfadfåp)</dcvalue>
   <dcvalue element="description" qualifier="provenance" language="en">Gurba&#x20;Gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;gurba&#x20;(øæsdfadfåp)</dcvalue>
   <dcvalue element="language" qualifier="iso" language="en_US">nob</dcvalue>

--- a/testinput/1/contents
+++ b/testinput/1/contents
@@ -1,4 +1,0 @@
-Random content.pdf	bundle:ORIGINAL	primary:true 
-license.txt	bundle:LICENSE
-Studie av av bla bla bla.pdf.txt	bundle:TEXT	description:Extracted text
-Studie av blablabla.pdf.jpg	bundle:THUMBNAIL	description:Generated Thumbnail


### PR DESCRIPTION
Fjernet fasterxml dependency da det ser ut som at den ikke er brukt. 

Inn i metoder hasValidIssn og hasValidIsbn returnerer jeg true dersom en ressurs ikke har isbn og/eller issn. Kan endre til false og skipe ressurs dersom den mangler de verdiene
