### PR TITLE
NP-26219-create-affiliations-based-on-file, affiliations implemented

### DIFF
--- a/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/record/Affiliation.java
+++ b/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/record/Affiliation.java
@@ -1,0 +1,60 @@
+package no.sikt.nva.brage.migration.common.model.record;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.util.Objects;
+import nva.commons.core.JacocoGenerated;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public class Affiliation {
+
+    private final String identifier;
+    private final String handle;
+    private final String name;
+
+    @JsonCreator
+    public Affiliation(@JsonProperty("identifier") String identifier,
+                       @JsonProperty("name") String name,
+                       @JsonProperty("handle") String handle) {
+        this.identifier = identifier;
+        this.name = name;
+        this.handle = handle;
+    }
+
+    @JsonProperty("handle")
+    public String getHandle() {
+        return handle;
+    }
+
+    @JsonProperty("identifier")
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JacocoGenerated
+    @Override
+    public int hashCode() {
+        return Objects.hash(getIdentifier(), getHandle(), getName());
+    }
+
+    @JacocoGenerated
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Affiliation that = (Affiliation) o;
+        return Objects.equals(getIdentifier(), that.getIdentifier())
+               && Objects.equals(getHandle(), that.getHandle())
+               && Objects.equals(getName(), that.getName());
+    }
+}

--- a/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/record/Contributor.java
+++ b/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/record/Contributor.java
@@ -4,13 +4,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.util.List;
 import java.util.Objects;
 import nva.commons.core.JacocoGenerated;
 
-@JsonPropertyOrder({"brageRole", "role", "identity"})
+@JsonPropertyOrder({"brageRole", "role", "identity", "affiliations"})
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class Contributor {
 
+    private List<Affiliation> affiliations;
     private Identity identity;
     private String role;
     private String brageRole;
@@ -18,10 +20,21 @@ public class Contributor {
     @JsonCreator
     public Contributor(@JsonProperty("identity") Identity identity,
                        @JsonProperty("role") String role,
-                       @JsonProperty("brageRole") String brageRole) {
+                       @JsonProperty("brageRole") String brageRole,
+                       @JsonProperty("affiliations") List<Affiliation> affiliations) {
         this.identity = identity;
         this.role = role;
         this.brageRole = brageRole;
+        this.affiliations = affiliations;
+    }
+
+    @JsonProperty("affiliations")
+    public List<Affiliation> getAffiliations() {
+        return affiliations;
+    }
+
+    public void setAffiliations(List<Affiliation> affiliations) {
+        this.affiliations = affiliations;
     }
 
     @JsonProperty("role")
@@ -50,10 +63,14 @@ public class Contributor {
         this.brageRole = brageRole;
     }
 
+    public void addAffiliation(Affiliation affiliation) {
+        affiliations.add(affiliation);
+    }
+
     @JacocoGenerated
     @Override
     public int hashCode() {
-        return Objects.hash(identity, role, brageRole);
+        return Objects.hash(getAffiliations(), getIdentity(), getRole(), getBrageRole());
     }
 
     @JacocoGenerated
@@ -66,8 +83,9 @@ public class Contributor {
             return false;
         }
         Contributor that = (Contributor) o;
-        return Objects.equals(brageRole, that.brageRole)
-               && Objects.equals(identity, that.identity)
-               && Objects.equals(role, that.role);
+        return Objects.equals(getAffiliations(), that.getAffiliations())
+               && Objects.equals(getIdentity(), that.getIdentity())
+               && Objects.equals(getRole(), that.getRole())
+               && Objects.equals(getBrageRole(), that.getBrageRole());
     }
 }

--- a/src/main/java/no/sikt/nva/BrageMigrationCommand.java
+++ b/src/main/java/no/sikt/nva/BrageMigrationCommand.java
@@ -20,6 +20,7 @@ import no.sikt.nva.brage.migration.common.model.record.Record;
 import no.sikt.nva.logutils.LogSetup;
 import no.sikt.nva.model.Embargo;
 import no.sikt.nva.scrapers.DublinCoreScraper;
+import no.sikt.nva.scrapers.EmbargoScraper;
 import no.sikt.nva.scrapers.HandleTitleMapReader;
 import no.unit.nva.s3.S3Driver;
 import nva.commons.core.JacocoGenerated;

--- a/src/main/java/no/sikt/nva/BrageProcessor.java
+++ b/src/main/java/no/sikt/nva/BrageProcessor.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import no.sikt.nva.brage.migration.common.model.BrageLocation;
 import no.sikt.nva.brage.migration.common.model.ErrorDetails;
+import no.sikt.nva.brage.migration.common.model.record.Affiliation;
 import no.sikt.nva.brage.migration.common.model.record.Customer;
 import no.sikt.nva.brage.migration.common.model.record.Record;
 import no.sikt.nva.brage.migration.common.model.record.content.ResourceContent;
@@ -18,10 +19,12 @@ import no.sikt.nva.exceptions.HandleException;
 import no.sikt.nva.model.Embargo;
 import no.sikt.nva.model.dublincore.DcValue;
 import no.sikt.nva.model.dublincore.DublinCore;
+import no.sikt.nva.scrapers.AffiliationsScraper;
 import no.sikt.nva.scrapers.ContentScraper;
 import no.sikt.nva.scrapers.CustomerMapper;
 import no.sikt.nva.scrapers.DublinCoreFactory;
 import no.sikt.nva.scrapers.DublinCoreScraper;
+import no.sikt.nva.scrapers.EmbargoScraper;
 import no.sikt.nva.scrapers.HandleScraper;
 import no.sikt.nva.scrapers.LicenseScraper;
 import no.sikt.nva.scrapers.ResourceOwnerMapper;
@@ -154,10 +157,11 @@ public class BrageProcessor implements Runnable {
             brageLocation.setHandle(getHandle(entryDirectory, dublinCore));
             var dublinCoreScraper = new DublinCoreScraper(enableOnlineValidation, shouldLookUpInChannelRegister);
             var record = dublinCoreScraper.validateAndParseDublinCore(dublinCore, brageLocation);
-            record.setCustomer(generateCustomer());
+            record.setCustomer(new Customer(customer, CustomerMapper.getCustomerUri(customer)));
             record.setResourceOwner(ResourceOwnerMapper.getResourceOwner(customer));
             record.setContentBundle(getContent(entryDirectory, brageLocation, licenseScraper, dublinCore));
             record.setBrageLocation(String.valueOf(brageLocation.getBrageBundlePath()));
+            injectAffiliationsToContributors(record);
             var errors = BrageProcessorValidator.getBrageProcessorErrors(entryDirectory, dublinCore);
             record.getErrors().addAll(errors);
             EmbargoScraper.checkForEmbargoFromSuppliedEmbargoFile(record, embargoes);
@@ -169,8 +173,21 @@ public class BrageProcessor implements Runnable {
         }
     }
 
-    private Customer generateCustomer() {
-        return new Customer(customer, CustomerMapper.getCustomerUri(customer));
+    private void injectAffiliationsToContributors(Record record) {
+        var affiliations = AffiliationsScraper.getAffiliations(new File("affiliations.txt"));
+        if (!affiliations.isEmpty()) {
+            var matchingAffiliations = affiliations.stream()
+                                           .filter(affiliation -> hasMatchingOrigins(affiliation, record))
+                                           .collect(Collectors.toList());
+            record.getEntityDescription()
+                .getContributors()
+                .forEach(contributor -> contributor.setAffiliations(matchingAffiliations));
+        }
+    }
+
+    private boolean hasMatchingOrigins(Affiliation affiliation, Record record) {
+        var recordOriginCollection = record.getBrageLocation().split("/")[0];
+        return affiliation.getHandle().split("/")[0].equals(recordOriginCollection);
     }
 
     private ResourceContent getContent(File entryDirectory, BrageLocation brageLocation,

--- a/src/main/java/no/sikt/nva/scrapers/AffiliationsScraper.java
+++ b/src/main/java/no/sikt/nva/scrapers/AffiliationsScraper.java
@@ -1,0 +1,47 @@
+package no.sikt.nva.scrapers;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import no.sikt.nva.brage.migration.common.model.record.Affiliation;
+
+public final class AffiliationsScraper {
+
+    public static List<Affiliation> getAffiliations(File file) {
+        try {
+            var string = Files.readString(file.toPath());
+            return convertStringToAffiliations(string);
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
+
+    private static List<Affiliation> convertStringToAffiliations(String string) {
+        List<String> list = Arrays.asList(string.split("\n"));
+        return list.stream()
+                   .map(AffiliationsScraper::toAffiliation)
+                   .collect(Collectors.toList());
+    }
+
+    private static Affiliation toAffiliation(String string) {
+        var affiliationValues = string.split(";");
+        return new Affiliation(getIdentifier(affiliationValues),
+                               getName(affiliationValues),
+                               getHandle(affiliationValues));
+    }
+
+    private static String getIdentifier(String... affiliationValues) {
+        return affiliationValues[3].trim();
+    }
+
+    private static String getName(String... affiliationValues) {
+        return affiliationValues[1];
+    }
+
+    private static String getHandle(String... affiliationValues) {
+        return affiliationValues[2].trim();
+    }
+}

--- a/src/main/java/no/sikt/nva/scrapers/EmbargoScraper.java
+++ b/src/main/java/no/sikt/nva/scrapers/EmbargoScraper.java
@@ -1,4 +1,4 @@
-package no.sikt.nva;
+package no.sikt.nva.scrapers;
 
 import static no.sikt.nva.scrapers.ContentScraper.EMPTY_LINE_REGEX;
 import java.io.File;

--- a/src/main/java/no/sikt/nva/scrapers/EntityDescriptionExtractor.java
+++ b/src/main/java/no/sikt/nva/scrapers/EntityDescriptionExtractor.java
@@ -72,6 +72,14 @@ public final class EntityDescriptionExtractor {
                    .collect(Collectors.toList());
     }
 
+    public static String extractIssue(DublinCore dublinCore) {
+        var issues = dublinCore.getDcValues().stream()
+                         .filter(DcValue::isIssue)
+                         .map(DcValue::scrapeValueAndSetToScraped)
+                         .collect(Collectors.toList());
+        return !issues.isEmpty() ? issues.get(0) : null;
+    }
+
     private static String modifyIfDateIsOfLocalDateTimeFormat(String date) {
         try {
             if (date.length() > LOCAL_DATE_MAX_LENGTH) {
@@ -157,14 +165,6 @@ public final class EntityDescriptionExtractor {
         return publicationInstance;
     }
 
-    public static String extractIssue(DublinCore dublinCore) {
-        var issues = dublinCore.getDcValues().stream()
-                         .filter(DcValue::isIssue)
-                         .map(DcValue::scrapeValueAndSetToScraped)
-                         .collect(Collectors.toList());
-        return !issues.isEmpty() ? issues.get(0) : null;
-    }
-
     private static String extractVolume(DublinCore dublinCore) {
         return dublinCore.getDcValues().stream()
                    .filter(DcValue::isVolume)
@@ -178,19 +178,19 @@ public final class EntityDescriptionExtractor {
         }
         String brageRole = dcValue.getQualifier().getValue();
         if (dcValue.isAuthor()) {
-            return Optional.of(new Contributor(identity, AUTHOR, brageRole));
+            return Optional.of(new Contributor(identity, AUTHOR, brageRole, List.of()));
         }
         if (dcValue.isAdvisor()) {
-            return Optional.of(new Contributor(identity, ADVISOR, brageRole));
+            return Optional.of(new Contributor(identity, ADVISOR, brageRole, List.of()));
         }
         if (dcValue.isEditor()) {
-            return Optional.of(new Contributor(identity, EDITOR, brageRole));
+            return Optional.of(new Contributor(identity, EDITOR, brageRole, List.of()));
         }
         if (dcValue.isIllustrator()) {
-            return Optional.of(new Contributor(identity, ILLUSTRATOR, brageRole));
+            return Optional.of(new Contributor(identity, ILLUSTRATOR, brageRole, List.of()));
         }
         if (dcValue.isOtherContributor()) {
-            return Optional.of(new Contributor(identity, OTHER_CONTRIBUTOR, brageRole));
+            return Optional.of(new Contributor(identity, OTHER_CONTRIBUTOR, brageRole, List.of()));
         }
         return Optional.empty();
     }

--- a/src/test/java/no/sikt/nva/scrapers/AffiliationsScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/AffiliationsScraperTest.java
@@ -1,0 +1,22 @@
+package no.sikt.nva.scrapers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import java.io.File;
+import java.util.List;
+import no.sikt.nva.brage.migration.common.model.record.Affiliation;
+import org.junit.jupiter.api.Test;
+
+public class AffiliationsScraperTest {
+
+    public static final String TEST_FILE_LOCATION = "src/test/resources/affiliations.txt";
+
+    @Test
+    void shouldCreateAffiliationsFromFile() {
+        var expectedAffiliations = List.of(
+            new Affiliation("184.12.11.0", "Master theses (Department of Mathematics)", "1956/19599"),
+            new Affiliation("184.13.26.0", "Department of Global Public Health and Primary Care", "1956/939"));
+        var actualAffiliations = AffiliationsScraper.getAffiliations(new File(TEST_FILE_LOCATION));
+        assertThat(actualAffiliations, equalTo(expectedAffiliations));
+    }
+}

--- a/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
@@ -94,7 +94,7 @@ public class DublinCoreScraperTest {
     void shouldCreateContributor() {
 
         List<Contributor> expectedContributors = List.of(
-            new Contributor(new Identity("Some Person"), ADVISOR, Qualifier.ADVISOR.getValue()));
+            new Contributor(new Identity("Some Person"), ADVISOR, Qualifier.ADVISOR.getValue(), List.of()));
         var typeDcValue = new DcValue(Element.TYPE, null, "Others");
         var advisorDcValue = new DcValue(Element.CONTRIBUTOR, Qualifier.ADVISOR, "Some Person");
         var dublinCore = DublinCoreFactory.createDublinCoreWithDcValues(List.of(advisorDcValue, typeDcValue));

--- a/src/test/java/no/sikt/nva/scrapers/EmbargoScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/EmbargoScraperTest.java
@@ -1,4 +1,4 @@
-package no.sikt.nva;
+package no.sikt.nva.scrapers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/src/test/resources/affiliations.txt
+++ b/src/test/resources/affiliations.txt
@@ -1,0 +1,2 @@
+b054e1fe-a7ea-45e7-9bb0-7978a68d0cb5;Master theses (Department of Mathematics);1956/19599;184.12.11.0
+b4e745e5-07a2-4747-b0db-e5d6d96d5061;Department of Global Public Health and Primary Care;1956/939;184.13.26.0


### PR DESCRIPTION
- Extracts affiliations from affiliations.txt and applies them to all contributors in given collection (zip file in eksport directory).
- Thinking about merging it in main after we have migrated NVE to prod