### PR TITLE
hardcoded critin type added

### DIFF
--- a/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/NvaType.java
+++ b/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/NvaType.java
@@ -32,7 +32,8 @@ public enum NvaType {
     SCIENTIFIC_MONOGRAPH("Vitenskapelig monografi"),
     SCIENTIFIC_CHAPTER("Vitenskapelig kapittel"),
     SCIENTIFIC_ARTICLE("Vitenskapelig artikkel"),
-    CONFERENCE_REPORT("ConferenceReport");
+    CONFERENCE_REPORT("ConferenceReport"),
+    CRISTIN_RECORD("CristinRecord");
 
     private final String value;
 


### PR DESCRIPTION
When record has unsupported type but has cristin identifier, we expect to merge that record in NVA and adding CRISTIN_RECORD type, only files and some fields as keywords of this record will be used in future NVA publication.