### PR TITLE
sending unzipped collection as input

### DIFF
--- a/src/main/java/no/sikt/nva/BrageProcessorFactory.java
+++ b/src/main/java/no/sikt/nva/BrageProcessorFactory.java
@@ -30,7 +30,7 @@ public class BrageProcessorFactory {
                                                final boolean shouldLookUpInChannelRegister,
                                                final boolean noHandleCheck,
                                                final String awsEnvironment,
-                                               String outputDirectory) {
+                                               String outputDirectory, boolean isUnzipped) {
         var destinationDirectory = generateDestinationDirectory(outputDirectory, zipfile);
         if (StringUtils.isEmpty(destinationDirectory)) {
             throw new RuntimeException(INVALID_ZIPFILE_NAME_EXCEPTION_MESSAGE);
@@ -38,7 +38,7 @@ public class BrageProcessorFactory {
         return new BrageProcessor(zipfile, customer, destinationDirectory, rescueTitleAndHandleMap,
                                   enableOnlineValidation, shouldLookUpInChannelRegister, noHandleCheck,
                                   awsEnvironment, embargoes,
-                                  contributors);
+                                  contributors, isUnzipped);
     }
 
     private static int getLength(String zipfile) {


### PR DESCRIPTION
Problemstilling:

Folk ønsker at vi skal kjøre samlinger som kommer inn som .tar fil eller merkelig zip format som vi ikke klarer å unzippe, 
men som kan pakkes ut ved bruk av jar xf kommandoen. 

Jeg tror ikke at vi ønsker å lage støtte for utpakkingen av alle mulige filformater.

Løsning: Lage støtte for å kunne konsumere ressurser som allerede er pakket ut. 