### PR TITLE
Np 45331 add more customers

### DIFF
--- a/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/BrageType.java
+++ b/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/BrageType.java
@@ -7,7 +7,7 @@ public enum BrageType {
     CHAPTER("Chapter"),
     DATASET("Dataset"),
     DATA_SET("Data set"),
-    JOURNAL_s("Journal article"),
+    JOURNAL_ARTICLE("Journal article"),
     ARTICLE("Article"),
     JOURNAL_ISSUE("Journal issue"),
     OTHERS("Others"),

--- a/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/BrageType.java
+++ b/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/BrageType.java
@@ -7,7 +7,7 @@ public enum BrageType {
     CHAPTER("Chapter"),
     DATASET("Dataset"),
     DATA_SET("Data set"),
-    JOURNAL_ARTICLE("Journal article"),
+    JOURNAL_s("Journal article"),
     ARTICLE("Article"),
     JOURNAL_ISSUE("Journal issue"),
     OTHERS("Others"),

--- a/src/main/java/no/sikt/nva/scrapers/CustomerMapper.java
+++ b/src/main/java/no/sikt/nva/scrapers/CustomerMapper.java
@@ -5,7 +5,9 @@ import java.net.URI;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
+@SuppressWarnings("PMD.DoubleBraceInitialization")
 public class CustomerMapper {
 
     public static final String AHO = "aho";
@@ -61,220 +63,352 @@ public class CustomerMapper {
     public static final String PROD = "prod";
     public static final String NB = "nb";
     public static final String NFORSK = "nforsk";
-    private static final Map<String, Map<String, String>> CUSTOMER_MAP = Map.ofEntries(
-        entry(NUPI, Map.ofEntries(
-                    entry(SANDBOX, ""),
-                    entry(DEVELOP, "8d11f0f0-d414-4564-9250-298c06ef5c87"),
-                    entry(TEST, "122d33a7-1844-466a-926b-333eeff42a93"),
-                    entry(PROD, ""))),
-        entry(OMSORGSFORSKNING, Map.ofEntries(
+    public static final String CICERO = "cicero";
+    public static final String FNI = "fni";
+    public static final String NLA = "nla";
+    public static final String NINA = "nina";
+    public static final String NMBU = "nmbu";
+    public static final String NMH = "nmh";
+    public static final String NOFIMA = "nofima";
+    public static final String NORCERESEARCH = "norceresearch";
+    public static final String NORSKFOLKEMUSEUM = "norskfolkemuseum";
+    public static final String NPOLAR = "npolar";
+    public static final String RURALIS = "ruralis";
+    public static final String SAMAS = "samas";
+    public static final String SAMFUNNSFORSKNING = "samfunnsforskning";
+    public static final String SIHF = "sihf";
+    public static final String SINTEF = "sintef";
+    public static final String SSB = "ssb";
+    public static final String UIS = "uis";
+    public static final String USN = "usn";
+    public static final String NIKU = "niku";
+    public static final String NILU = "nilu";
+    public static final String NGU = "ngu";
+    public static final String UIT = "uit";
+    public static final String UIO = "uio";
+    private static final Map<String, Map<String, String>> CUSTOMER_MAP = new ConcurrentHashMap<>()
+    {{
+
+            put(NUPI, Map.ofEntries(
+                entry(SANDBOX, ""),
+                entry(DEVELOP, "8d11f0f0-d414-4564-9250-298c06ef5c87"),
+                entry(TEST, "122d33a7-1844-466a-926b-333eeff42a93"),
+                entry(PROD, "")));
+                put(OMSORGSFORSKNING, Map.ofEntries(
                     entry(SANDBOX, ""),
                     entry(DEVELOP, ""),
                     entry(TEST, ""),
-                    entry(PROD, ""))),
-        entry(INN, Map.ofEntries(
+                    entry(PROD, "")));
+                put(INN, Map.ofEntries(
                     entry(SANDBOX, ""),
                     entry(DEVELOP, "023f1608-1baa-4d5a-8acc-80d329bddd74"),
                     entry(TEST, "df2a796f-3eef-45dc-a39d-51b21989285a"),
-                    entry(PROD, ""))),
-        entry(BI, Map.ofEntries(
+                    entry(PROD, "")));
+                put(BI, Map.ofEntries(
                     entry(SANDBOX, ""),
                     entry(DEVELOP, "a49a2deb-f782-4ab1-b2ab-97745bc14b3d"),
                     entry(TEST, "e9fb0c5d-1589-4d6f-932f-b312e50daa8f"),
-                    entry(PROD, ""))),
-        entry(VID, Map.ofEntries(
+                    entry(PROD, "")));
+                put(VID, Map.ofEntries(
                     entry(SANDBOX, ""),
                     entry(DEVELOP, "58d2d14c-ff23-4aa0-94f1-b53190fd020a"),
                     entry(TEST, "9b17e692-6690-41a2-923b-b7ac0d7a1522"),
-                    entry(PROD, ""))),
-        entry(BANENOR, Map.ofEntries(
+                    entry(PROD, "")));
+                put(BANENOR, Map.ofEntries(
                     entry(SANDBOX, ""),
                     entry(DEVELOP, ""),
                     entry(TEST, ""),
-                    entry(PROD, ""))),
-        entry(RA, Map.ofEntries(
+                    entry(PROD, "")));
+                put(RA, Map.ofEntries(
                     entry(SANDBOX, "b3435185-929a-4842-96ee-4243f4c9078c"),
                     entry(DEVELOP, "e974d7d1-50b5-47c0-ad7e-7135a2d47555"),
                     entry(TEST, "434ed8ed-f302-409f-9943-8886320550a3"),
-                    entry(PROD, ""))),
-        entry(NORGES_BANK, Map.ofEntries(
+                    entry(PROD, "")));
+                put(NORGES_BANK, Map.ofEntries(
                     entry(SANDBOX, ""),
                     entry(DEVELOP, "9d02e866-aeba-466d-993a-b519c664d38c"),
                     entry(TEST, "2d37e9a9-dc70-4c30-bdb6-c7724eb7f0c3"),
-                    entry(PROD, ""))),
-        entry(NVE, Map.ofEntries(entry(SANDBOX, "5eb7ca32-0e6b-4819-b794-c31a4b16ea6b"),
+                    entry(PROD, "")));
+                put(NVE, Map.ofEntries(
+                    entry(SANDBOX, "5eb7ca32-0e6b-4819-b794-c31a4b16ea6b"),
                     entry(DEVELOP, "b4497570-2903-49a2-9c2a-d6ab8b0eacc2"),
                     entry(TEST, ""),
-                    entry(PROD, "4ba5f697-2056-4292-b0a3-f81ccf21ea22"))),
-
-        entry(KRUS, Map.ofEntries(entry(SANDBOX, "6b5e1238-7a05-11ed-a1eb-0242ac120002"),
+                    entry(PROD, "4ba5f697-2056-4292-b0a3-f81ccf21ea22")));
+                put(KRUS, Map.ofEntries(
+                    entry(SANDBOX, "6b5e1238-7a05-11ed-a1eb-0242ac120002"),
                     entry(DEVELOP, "a768727e-4ecb-41c1-a616-1fec000cac1c"),
                     entry(TEST, ""),
-                    entry(PROD, ""))),
-
-        entry(KRISTIANIA, Map.ofEntries(entry(SANDBOX, "8fb3c2f4-da97-4eb1-be65-307c86b993ee"),
+                    entry(PROD, "")));
+                put(KRISTIANIA, Map.ofEntries(
+                    entry(SANDBOX, "8fb3c2f4-da97-4eb1-be65-307c86b993ee"),
                     entry(DEVELOP, "ca57b418-f837-40fd-af5c-5a6ba14abd7e"),
                     entry(TEST, "c1d7b72b-3319-4a1f-a365-c04ddb729b6f"),
-                    entry(PROD, "05329411-0aa7-4c68-8cc6-5875f0d58f8c"))),
-
-        entry(FHS, Map.ofEntries(entry(SANDBOX, ""),
+                    entry(PROD, "05329411-0aa7-4c68-8cc6-5875f0d58f8c")));
+                put(FHS, Map.ofEntries(
+                    entry(SANDBOX, ""),
                     entry(DEVELOP, "290bb113-cf83-4917-8a07-463b4eca057b"),
                     entry(TEST, "ba0b80e8-ca87-4b8f-bf2a-6d00188ad707"),
-                    entry(PROD, ""))),
-
-        entry(HIOF, Map.ofEntries(entry(SANDBOX, ""),
-                                  entry(DEVELOP, "5c243c2d-a8fb-48fb-a2c6-c6fa70310194"),
-                                  entry(TEST, "719fdb5a-f90a-4e20-b81d-1dde3ca6e647"),
-                                  entry(PROD, ""))),
-
-        entry(NGI, Map.ofEntries(entry(SANDBOX, ""),
-                                 entry(DEVELOP, "f415cb81-ac56-4244-b31b-25e43dc3027e"),
-                                 entry(TEST, "1f899570-ed06-4c08-bc9f-ed92402e5128"),
-                                 entry(PROD, ""))),
-
-        entry(NIBIO, Map.ofEntries(entry(SANDBOX, ""),
-                                   entry(DEVELOP, "82c8b036-39cb-4ac2-8a2d-152cda4bcc27"),
-                                   entry(TEST, "cd925eea-7f4c-4167-9b7c-a7bf7f8eca59"),
-                                   entry(PROD, "77766640-6066-48ef-a32c-0ba7f32abee9"))),
-
-        entry(NIH, Map.ofEntries(entry(SANDBOX, ""),
-                                 entry(DEVELOP, "b5ff15a1-0e58-44bf-b137-d5c5389ef63f"),
-                                 entry(TEST, "6c7ac184-1b21-425c-a422-2855804be2aa"),
-                                 entry(PROD, ""))),
-        entry(NTNU, Map.ofEntries(entry(SANDBOX, ""),
-                                  entry(DEVELOP, "8ddecceb-7d64-4df3-a842-489fe4d98f3a"),
-                                  entry(TEST, "33c17ef6-864b-4267-bc9d-0cee636e247e"),
-                                  entry(PROD, ""))),
-        entry(NR, Map.ofEntries(entry(SANDBOX, ""),
-                                entry(DEVELOP, "54bed9d9-2bc4-4fa4-a6c4-9e957f93870d"),
-                                entry(TEST, "505328d2-1992-406c-8792-b064748d2f38"),
-                                entry(PROD, ""))),
-        entry(SAMFORSK, Map.ofEntries(entry(SANDBOX, ""),
-                                      entry(DEVELOP, "6da57387-b48a-46dc-a395-d07c12b1e54b"),
+                    entry(PROD, "")));
+                put(HIOF, Map.ofEntries(
+                    entry(SANDBOX, ""),
+                    entry(DEVELOP, "5c243c2d-a8fb-48fb-a2c6-c6fa70310194"),
+                    entry(TEST, "719fdb5a-f90a-4e20-b81d-1dde3ca6e647"),
+                    entry(PROD, "")));
+                put(NGI, Map.ofEntries(
+                    entry(SANDBOX, ""),
+                    entry(DEVELOP, "f415cb81-ac56-4244-b31b-25e43dc3027e"),
+                    entry(TEST, "1f899570-ed06-4c08-bc9f-ed92402e5128"),
+                    entry(PROD, "")));
+                put(NIBIO, Map.ofEntries(
+                    entry(SANDBOX, ""),
+                    entry(DEVELOP, "82c8b036-39cb-4ac2-8a2d-152cda4bcc27"),
+                    entry(TEST, "cd925eea-7f4c-4167-9b7c-a7bf7f8eca59"),
+                    entry(PROD, "77766640-6066-48ef-a32c-0ba7f32abee9")));
+                put(NIH, Map.ofEntries(
+                    entry(SANDBOX, ""),
+                    entry(DEVELOP, "b5ff15a1-0e58-44bf-b137-d5c5389ef63f"),
+                    entry(TEST, "6c7ac184-1b21-425c-a422-2855804be2aa"),
+                    entry(PROD, "")));
+                put(NTNU, Map.ofEntries(
+                    entry(SANDBOX, ""),
+                    entry(DEVELOP, "8ddecceb-7d64-4df3-a842-489fe4d98f3a"),
+                    entry(TEST, "33c17ef6-864b-4267-bc9d-0cee636e247e"),
+                    entry(PROD, "")));
+                put(NR, Map.ofEntries(
+                    entry(SANDBOX, ""),
+                    entry(DEVELOP, "54bed9d9-2bc4-4fa4-a6c4-9e957f93870d"),
+                    entry(TEST, "505328d2-1992-406c-8792-b064748d2f38"),
+                    entry(PROD, "")));
+                put(SAMFORSK, Map.ofEntries(
+                    entry(SANDBOX, ""),
+                    entry(DEVELOP, "6da57387-b48a-46dc-a395-d07c12b1e54b"),
+                    entry(TEST, ""),
+                    entry(PROD, "")));
+                put(CMI, Map.ofEntries(
+                    entry(SANDBOX, ""),
+                    entry(DEVELOP, "aebc37b9-593c-42b6-88bf-0d8a54492a32"),
+                    entry(TEST, ""),
+                    entry(PROD, "")));
+                put(DMMH, Map.ofEntries(
+                    entry(SANDBOX, ""),
+                    entry(DEVELOP, "0edc1e9a-a74b-4169-86ba-f98b92d0115e"),
+                    entry(TEST, "2e4f348c-47a3-4500-94dd-9b4ee4ba63d9"),
+                    entry(PROD, "")));
+                put(FAFO, Map.ofEntries(
+                    entry(SANDBOX, ""),
+                    entry(DEVELOP, "eab76eb2-3f15-40af-9056-53946ec8fcde"),
+                    entry(TEST, "648a3ed0-f34e-48ff-8db9-092b2f5d5fa2"),
+                    entry(PROD, "")));
+                put(FDIR, Map.ofEntries(
+                    entry(SANDBOX, ""),
+                    entry(DEVELOP, "4403a49b-a175-4985-a695-f16c5b87c9ac"),
+                    entry(TEST, ""),
+                    entry(PROD, "")));
+                put(UIA, Map.ofEntries(
+                    entry(SANDBOX, ""),
+                    entry(DEVELOP, "8b77046d-2001-47cb-b061-0346d5b4b95c"),
+                    entry(TEST, "2732ed9a-971a-4e34-ac84-d5f6d067ed66"),
+                    entry(PROD, "20c7aad5-af76-4909-afe2-cdc9c7ec4f79")));
+                put(NORD, Map.ofEntries(
+                    entry(SANDBOX, ""),
+                    entry(DEVELOP, "f94d1d3e-e05a-41f9-8eb8-f891ccd25666"),
+                    entry(TEST, "27c650e1-9af2-40fd-91c0-3abdf38c86f0"),
+                    entry(PROD, "0e878881-87b9-4392-b4e4-b410bbecbd1d")));
+                put(ODA, Map.ofEntries(entry(SANDBOX, ""),
+                                       entry(DEVELOP, "8db4a8bd-3db5-420b-a2e4-fc17a489aa6d"),
+                                       entry(TEST, ""),
+                                       entry(PROD, "")));
+                put(HIMOLDE, Map.ofEntries(entry(SANDBOX, ""),
+                                           entry(DEVELOP, "2927ca20-cbd0-4b0a-abd3-3de23e8f2065"),
+                                           entry(TEST, "e8833011-2e16-4765-b1dd-494b64c8d646"),
+                                           entry(PROD, "9e6b93b6-1ef2-4b91-9599-ebc9ac8c6606")));
+                put(HIVOLDA, Map.ofEntries(entry(SANDBOX, ""),
+                                           entry(DEVELOP, "9c81f056-5839-4843-9b93-20962281df38"),
+                                           entry(TEST, "235dc022-6beb-4f8f-8165-9fbe680e1f5b"),
+                                           entry(PROD, "ca410109-2720-475b-a280-59783e2962c7")));
+                put(HVLOPEN, Map.ofEntries(entry(SANDBOX, ""),
+                                           entry(DEVELOP, "fe945ea8-22d1-481c-b5be-4e0447d5656c"),
+                                           entry(TEST, "d60e86ef-2bcd-4e0b-8872-43f80858caaa"),
+                                           entry(PROD, "2e3ae52c-ada5-4862-b72a-98e74690465c")));
+                put(NHH, Map.ofEntries(entry(SANDBOX, ""),
+                                       entry(DEVELOP, "418e4bf8-6f7e-419c-b7b7-45bcbab38429"),
+                                       entry(TEST, "7bf52e6f-82dc-4203-a25e-93630819b741"),
+                                       entry(PROD, "1432ce2a-5f2e-4560-8b6c-9af87c082d53")));
+                put(BORA, Map.ofEntries(entry(SANDBOX, ""),
+                                        entry(DEVELOP, "a228aba6-932b-4f53-b2de-31ad8daf9f8d"),
+                                        entry(TEST, "7c41e7cd-f494-4266-9979-48285cbb2434"),
+                                        entry(PROD, "2f42a7e8-219b-4289-9b41-99b32a6b4866")));
+                put(AHO, Map.ofEntries(entry(SANDBOX, ""),
+                                       entry(DEVELOP, ""),
+                                       entry(TEST, "ba0b80e8-ca87-4b8f-bf2a-6d00188ad707"),
+                                       entry(PROD, "")));
+                put(IFE, Map.ofEntries(entry(SANDBOX, ""),
+                                       entry(DEVELOP, "d13b4e4e-5dfe-4c92-b6d9-dab1b910cb02"),
+                                       entry(TEST, "6c55e437-b373-4875-8505-d0af113aec59"),
+                                       entry(PROD, "")));
+                put(KHIO, Map.ofEntries(entry(SANDBOX, ""),
+                                        entry(DEVELOP, "67e867aa-e925-4697-bad0-c2125c1d6a7c"),
+                                        entry(TEST, "130e5373-9673-4d66-a0d3-d22a2874b32f"),
+                                        entry(PROD, "")));
+                put(LDH, Map.ofEntries(entry(SANDBOX, ""),
+                                       entry(DEVELOP, "367b47d3-8532-47ca-aebf-e3553bea76a8"),
+                                       entry(TEST, "2197e9e0-93b0-4051-8044-16ffd0087982"),
+                                       entry(PROD, "")));
+                put(MF, Map.ofEntries(entry(SANDBOX, ""),
+                                      entry(DEVELOP, "2287bd5f-7ac9-4ad0-b70f-0ce6575adea3"),
+                                      entry(TEST, "577c0a2f-2697-4401-ad94-0a9bf20bdb40"),
+                                      entry(PROD, "")));
+                put(NIFU, Map.ofEntries(entry(SANDBOX, ""),
+                                        entry(DEVELOP, "043ad701-d2c5-46be-b991-c58aef97626d"),
+                                        entry(TEST, "f09c78fe-0d6a-4e45-be1c-6fede449cda8"),
+                                        entry(PROD, "")));
+                put(NIVA, Map.ofEntries(entry(SANDBOX, ""),
+                                        entry(DEVELOP, "6c94a30a-d4cf-47d7-8de1-7ed3d145f183"),
+                                        entry(TEST, "a497cf56-1a26-4de3-b2cc-ec20aa54af10"),
+                                        entry(PROD, "")));
+                put(PHS, Map.ofEntries(entry(SANDBOX, ""),
+                                       entry(DEVELOP, "a0df7c41-35f8-4080-a86f-4da018572f54"),
+                                       entry(TEST, "f20f314d-fa91-4c66-9131-98b6c4fed42e"),
+                                       entry(PROD, "1b36e4bf-223c-4da7-9bae-35846106c788")));
+                put(STAMI, Map.ofEntries(entry(SANDBOX, ""),
+                                         entry(DEVELOP, "838c45e1-8470-490b-b71d-a947b444e220"),
+                                         entry(TEST, "959587b0-d49b-49c8-adb4-43910500c2c3"),
+                                         entry(PROD, "")));
+                put(STEINERHOYSKOLEN, Map.ofEntries(entry(SANDBOX, ""),
+                                                    entry(DEVELOP, "a739d345-a564-4f0e-adec-c8c9ecb09bbb"),
+                                                    entry(TEST, "57bb7742-271a-4a17-ac4c-d142cb598edb"),
+                                                    entry(PROD, "")));
+                put(VETINST, Map.ofEntries(entry(SANDBOX, ""),
+                                           entry(DEVELOP, "cd13fb16-8f88-4216-bc92-d2e63c9fd393"),
+                                           entry(TEST, "2ccab0d9-c238-4fb6-b417-58586cf0ed22"),
+                                           entry(PROD, "1987c64c-3830-46c0-90e0-2603162e0d88")));
+                put(NASJONALMUSEET, Map.ofEntries(entry(SANDBOX, ""),
+                                                  entry(DEVELOP, "bbd9048d-e51b-49f6-b699-fd86ec86acd6"),
+                                                  entry(TEST, "63efab04-c807-4efa-8ee9-a2c3ae6f77af"),
+                                                  entry(PROD, "")));
+                put(UNIT, Map.ofEntries(entry(SANDBOX, ""),
+                                        entry(DEVELOP, "bbd9048d-e51b-49f6-b699-fd86ec86acd6"),
+                                        entry(TEST, "ed671c06-964c-46ce-85d5-777c164ac81e"),
+                                        entry(PROD, "")));
+                put(STATPED, Map.ofEntries(entry(SANDBOX, ""),
+                                           entry(DEVELOP, "e6890d28-a370-49a3-9100-f78b2e8fb324"),
+                                           entry(TEST, "82fa69db-a834-47e2-8d03-048b3f60cbcf"),
+                                           entry(PROD, "a63f80aa-d479-4271-8a17-d82ab7d0efd2")));
+                put(VEGVESEN, Map.ofEntries(entry(SANDBOX, ""),
+                                            entry(DEVELOP, "2c1deeca-c0fc-487e-93c8-9f0cf4fae490"),
+                                            entry(TEST, "95100df5-b46b-41c9-a87a-9a2efc58716e"),
+                                            entry(PROD, "")));
+                put(FFI, Map.ofEntries(entry(SANDBOX, ""),
+                                       entry(DEVELOP, "04939e4d-105e-4d3c-b945-7d482d4f18d5"),
+                                       entry(TEST, ""),
+                                       entry(PROD, "")));
+                put(NB, Map.ofEntries(entry(SANDBOX, ""),
+                                      entry(DEVELOP, "9fde89c7-baea-4ac1-ad52-97d4dee0e6da"),
                                       entry(TEST, ""),
-                                      entry(PROD, ""))),
-        entry(CMI, Map.ofEntries(entry(SANDBOX, ""),
-                                 entry(DEVELOP, "aebc37b9-593c-42b6-88bf-0d8a54492a32"),
-                                 entry(TEST, ""),
-                                 entry(PROD, ""))),
-        entry(DMMH, Map.ofEntries(entry(SANDBOX, ""),
-                                  entry(DEVELOP, "0edc1e9a-a74b-4169-86ba-f98b92d0115e"),
-                                  entry(TEST, "2e4f348c-47a3-4500-94dd-9b4ee4ba63d9"),
-                                  entry(PROD, ""))),
-        entry(FAFO, Map.ofEntries(entry(SANDBOX, ""),
-                                  entry(DEVELOP, "eab76eb2-3f15-40af-9056-53946ec8fcde"),
-                                  entry(TEST, "648a3ed0-f34e-48ff-8db9-092b2f5d5fa2"),
-                                  entry(PROD, ""))),
-        entry(FDIR, Map.ofEntries(entry(SANDBOX, ""),
-                                  entry(DEVELOP, "4403a49b-a175-4985-a695-f16c5b87c9ac"),
-                                  entry(TEST, ""),
-                                  entry(PROD, ""))),
-        entry(UIA, Map.ofEntries(entry(SANDBOX, ""),
-                                 entry(DEVELOP, "8b77046d-2001-47cb-b061-0346d5b4b95c"),
-                                 entry(TEST, "2732ed9a-971a-4e34-ac84-d5f6d067ed66"),
-                                 entry(PROD, "20c7aad5-af76-4909-afe2-cdc9c7ec4f79"))),
-        entry(NORD, Map.ofEntries(entry(SANDBOX, ""),
-                                  entry(DEVELOP, "f94d1d3e-e05a-41f9-8eb8-f891ccd25666"),
-                                  entry(TEST, "27c650e1-9af2-40fd-91c0-3abdf38c86f0"),
-                                  entry(PROD, "0e878881-87b9-4392-b4e4-b410bbecbd1d"))),
-        entry(ODA, Map.ofEntries(entry(SANDBOX, ""),
-                                 entry(DEVELOP, "8db4a8bd-3db5-420b-a2e4-fc17a489aa6d"),
-                                 entry(TEST, ""),
-                                 entry(PROD, ""))),
-        entry(HIMOLDE, Map.ofEntries(entry(SANDBOX, ""),
-                                     entry(DEVELOP, "2927ca20-cbd0-4b0a-abd3-3de23e8f2065"),
-                                     entry(TEST, "e8833011-2e16-4765-b1dd-494b64c8d646"),
-                                     entry(PROD, "9e6b93b6-1ef2-4b91-9599-ebc9ac8c6606"))),
-        entry(HIVOLDA, Map.ofEntries(entry(SANDBOX, ""),
-                                     entry(DEVELOP, "9c81f056-5839-4843-9b93-20962281df38"),
-                                     entry(TEST, "235dc022-6beb-4f8f-8165-9fbe680e1f5b"),
-                                     entry(PROD, "ca410109-2720-475b-a280-59783e2962c7"))),
-        entry(HVLOPEN, Map.ofEntries(entry(SANDBOX, ""),
-                                     entry(DEVELOP, "fe945ea8-22d1-481c-b5be-4e0447d5656c"),
-                                     entry(TEST, "d60e86ef-2bcd-4e0b-8872-43f80858caaa"),
-                                     entry(PROD, "2e3ae52c-ada5-4862-b72a-98e74690465c"))),
-        entry(NHH, Map.ofEntries(entry(SANDBOX, ""),
-                                 entry(DEVELOP, "418e4bf8-6f7e-419c-b7b7-45bcbab38429"),
-                                 entry(TEST, "7bf52e6f-82dc-4203-a25e-93630819b741"),
-                                 entry(PROD, "1432ce2a-5f2e-4560-8b6c-9af87c082d53"))),
-        entry(BORA, Map.ofEntries(entry(SANDBOX, ""),
-                                  entry(DEVELOP, "a228aba6-932b-4f53-b2de-31ad8daf9f8d"),
-                                  entry(TEST, "7c41e7cd-f494-4266-9979-48285cbb2434"),
-                                  entry(PROD, "2f42a7e8-219b-4289-9b41-99b32a6b4866"))),
-        entry(AHO, Map.ofEntries(entry(SANDBOX, ""),
-                                 entry(DEVELOP, ""),
-                                 entry(TEST, "ba0b80e8-ca87-4b8f-bf2a-6d00188ad707"),
-                                 entry(PROD, ""))),
-        entry(IFE, Map.ofEntries(entry(SANDBOX, ""),
-                                 entry(DEVELOP, "d13b4e4e-5dfe-4c92-b6d9-dab1b910cb02"),
-                                 entry(TEST, "6c55e437-b373-4875-8505-d0af113aec59"),
-                                 entry(PROD, ""))),
-        entry(KHIO, Map.ofEntries(entry(SANDBOX, ""),
-                                  entry(DEVELOP, "67e867aa-e925-4697-bad0-c2125c1d6a7c"),
-                                  entry(TEST, "130e5373-9673-4d66-a0d3-d22a2874b32f"),
-                                  entry(PROD, ""))),
-        entry(LDH, Map.ofEntries(entry(SANDBOX, ""),
-                                 entry(DEVELOP, "367b47d3-8532-47ca-aebf-e3553bea76a8"),
-                                 entry(TEST, "2197e9e0-93b0-4051-8044-16ffd0087982"),
-                                 entry(PROD, ""))),
-        entry(MF, Map.ofEntries(entry(SANDBOX, ""),
-                                entry(DEVELOP, "2287bd5f-7ac9-4ad0-b70f-0ce6575adea3"),
-                                entry(TEST, "577c0a2f-2697-4401-ad94-0a9bf20bdb40"),
-                                entry(PROD, ""))),
-        entry(NIFU, Map.ofEntries(entry(SANDBOX, ""),
-                                  entry(DEVELOP, "043ad701-d2c5-46be-b991-c58aef97626d"),
-                                  entry(TEST, "f09c78fe-0d6a-4e45-be1c-6fede449cda8"),
-                                  entry(PROD, ""))),
-        entry(NIVA, Map.ofEntries(entry(SANDBOX, ""),
-                                  entry(DEVELOP, "6c94a30a-d4cf-47d7-8de1-7ed3d145f183"),
-                                  entry(TEST, "a497cf56-1a26-4de3-b2cc-ec20aa54af10"),
-                                  entry(PROD, ""))),
-        entry(PHS, Map.ofEntries(entry(SANDBOX, ""),
-                                 entry(DEVELOP, "a0df7c41-35f8-4080-a86f-4da018572f54"),
-                                 entry(TEST, "f20f314d-fa91-4c66-9131-98b6c4fed42e"),
-                                 entry(PROD, "1b36e4bf-223c-4da7-9bae-35846106c788"))),
-        entry(STAMI, Map.ofEntries(entry(SANDBOX, ""),
-                                   entry(DEVELOP, "838c45e1-8470-490b-b71d-a947b444e220"),
-                                   entry(TEST, "959587b0-d49b-49c8-adb4-43910500c2c3"),
-                                   entry(PROD, ""))),
-        entry(STEINERHOYSKOLEN, Map.ofEntries(entry(SANDBOX, ""),
-                                              entry(DEVELOP, "a739d345-a564-4f0e-adec-c8c9ecb09bbb"),
-                                              entry(TEST, "57bb7742-271a-4a17-ac4c-d142cb598edb"),
-                                              entry(PROD, ""))),
-        entry(VETINST, Map.ofEntries(entry(SANDBOX, ""),
-                                     entry(DEVELOP, "cd13fb16-8f88-4216-bc92-d2e63c9fd393"),
-                                     entry(TEST, "2ccab0d9-c238-4fb6-b417-58586cf0ed22"),
-                                     entry(PROD, "1987c64c-3830-46c0-90e0-2603162e0d88"))),
-        entry(NASJONALMUSEET, Map.ofEntries(entry(SANDBOX, ""),
-                                            entry(DEVELOP, "bbd9048d-e51b-49f6-b699-fd86ec86acd6"),
-                                            entry(TEST, "63efab04-c807-4efa-8ee9-a2c3ae6f77af"),
-                                            entry(PROD, ""))),
-        entry(UNIT, Map.ofEntries(entry(SANDBOX, ""),
-                                  entry(DEVELOP, "bbd9048d-e51b-49f6-b699-fd86ec86acd6"),
-                                  entry(TEST, "ed671c06-964c-46ce-85d5-777c164ac81e"),
-                                  entry(PROD, ""))),
-        entry(STATPED, Map.ofEntries(entry(SANDBOX, ""),
-                                     entry(DEVELOP, "e6890d28-a370-49a3-9100-f78b2e8fb324"),
-                                     entry(TEST, "82fa69db-a834-47e2-8d03-048b3f60cbcf"),
-                                     entry(PROD, "a63f80aa-d479-4271-8a17-d82ab7d0efd2"))),
-        entry(VEGVESEN, Map.ofEntries(entry(SANDBOX, ""),
-                                      entry(DEVELOP, "2c1deeca-c0fc-487e-93c8-9f0cf4fae490"),
-                                      entry(TEST, "95100df5-b46b-41c9-a87a-9a2efc58716e"),
-                                      entry(PROD, ""))),
-        entry(FFI, Map.ofEntries(entry(SANDBOX, ""),
-                                 entry(DEVELOP, "04939e4d-105e-4d3c-b945-7d482d4f18d5"),
-                                 entry(TEST, ""),
-                                 entry(PROD, ""))),
-        entry(NB, Map.ofEntries(entry(SANDBOX, ""),
-                                entry(DEVELOP, "9fde89c7-baea-4ac1-ad52-97d4dee0e6da"),
-                                entry(TEST, ""),
-                                entry(PROD, ""))),
-        entry(NFORSK, Map.ofEntries(entry(SANDBOX, ""),
-                                    entry(DEVELOP, "5196161e-c952-4b36-9125-3e9746ee338d"),
-                                    entry(TEST, ""),
-                                    entry(PROD, "")))
+                                      entry(PROD, "")));
+                put(NFORSK, Map.ofEntries(entry(SANDBOX, ""),
+                                          entry(DEVELOP, "5196161e-c952-4b36-9125-3e9746ee338d"),
+                                          entry(TEST, ""),
+                                          entry(PROD, "")));
+                put(CICERO, Map.ofEntries(entry(SANDBOX, ""),
 
-    );
+                                          entry(DEVELOP, "d22e1273-5dd0-410f-a0d9-356353683a98"),
+
+                                          entry(TEST, "47db88b9-3013-4e53-873c-bb0003074ca3"),
+
+                                          entry(PROD, "")));
+                put(FNI, Map.ofEntries(entry(SANDBOX, ""),
+                                       entry(DEVELOP, "de17a451-0aec-4beb-a17f-ca6779e4e295"),
+                                       entry(TEST, ""),
+                                       entry(PROD, "")));
+                put(NLA, Map.ofEntries(entry(SANDBOX, ""),
+
+                                       entry(DEVELOP, "53fdf89c-7408-4371-bab9-89812ce34e91"),
+
+                                       entry(TEST, ""),
+
+                                       entry(PROD, "")));
+                put(NINA, Map.ofEntries(entry(SANDBOX, ""),
+                                        entry(DEVELOP, "afa4fb86-76f6-4339-9133-924d999a792e"),
+                                        entry(TEST, ""),
+                                        entry(PROD, "")));
+                put(NMBU, Map.ofEntries(entry(SANDBOX, ""),
+                                        entry(DEVELOP, "8b0609fc-8787-4c71-ba6d-fa3718bc73e1"),
+                                        entry(TEST, ""),
+                                        entry(PROD, "")));
+                put(NMH, Map.ofEntries(entry(SANDBOX, ""),
+                                       entry(DEVELOP, "2f148e5f-a017-4e7f-8f78-6a52eb6a9938"),
+                                       entry(TEST, ""),
+                                       entry(PROD, "")));
+                put(NOFIMA, Map.ofEntries(entry(SANDBOX, ""),
+                                          entry(DEVELOP, "15af7bc4-16cd-4134-91ba-68d900a5685c"),
+                                          entry(TEST, ""),
+                                          entry(PROD, "")));
+                put(NORCERESEARCH, Map.ofEntries(entry(SANDBOX, ""),
+                                                 entry(DEVELOP, "d039e7ea-1380-46f1-bb7d-b6456ddc0fc2"),
+                                                 entry(TEST, ""),
+                                                 entry(PROD, "")));
+                put(NORSKFOLKEMUSEUM, Map.ofEntries(entry(SANDBOX, ""),
+                                                    entry(DEVELOP, "890ae660-440f-41cb-9d57-1afa3f5d0444"),
+                                                    entry(TEST, ""),
+                                                    entry(PROD, "")));
+                put(NPOLAR, Map.ofEntries(entry(SANDBOX, ""),
+                                          entry(DEVELOP, "009974e9-217c-46b8-8f61-f7c1501ee04a"),
+                                          entry(TEST, ""),
+                                          entry(PROD, "")));
+                put(RURALIS, Map.ofEntries(entry(SANDBOX, ""),
+                                           entry(DEVELOP, "f8f52dc0-688c-4d56-b0f6-26e2698e16a0"),
+                                           entry(TEST, ""),
+                                           entry(PROD, "")));
+                put(SAMAS, Map.ofEntries(entry(SANDBOX, ""),
+                                         entry(DEVELOP, "69f64ed3-e2c6-4c0c-a370-0de946ca6568"),
+                                         entry(TEST, "b611090b-a768-4d89-a62d-ddd90f19ae22"),
+                                         entry(PROD, "")));
+                put(SAMFUNNSFORSKNING, Map.ofEntries(entry(SANDBOX, ""),
+                                                     entry(DEVELOP, "818c957b-65ce-447d-b78c-cd472ea0e65f"),
+                                                     entry(TEST, ""),
+                                                     entry(PROD, "")));
+                put(SIHF, Map.ofEntries(entry(SANDBOX, ""),
+                                        entry(DEVELOP, "73662b0f-4eba-4783-97da-de9e835affb6"),
+                                        entry(TEST, "ff990b53-59da-44b0-ba95-ac942a220d12"),
+                                        entry(PROD, "")));
+                put(SINTEF, Map.ofEntries(entry(SANDBOX, ""),
+                                          entry(DEVELOP, "11b70ff2-1ba4-4cf1-95f3-06fea953cf2e"),
+                                          entry(TEST, "dd70eb42-264a-4538-b77a-e31bb4cf3a99"),
+                                          entry(PROD, "")));
+            put(SSB, Map.ofEntries(entry(SANDBOX, ""),
+                                   entry(DEVELOP, "3169a5cb-db8b-44ac-8bab-69d3f4ff9f54"),
+                                   entry(TEST, "3f2485a8-ba56-48e2-827b-0a307a44eafb"),
+                                   entry(PROD, "")));
+                put(UIS, Map.ofEntries(entry(SANDBOX, ""),
+                                       entry(DEVELOP, "3e1da1fd-559e-4334-acb9-797684e5bae2"),
+                                       entry(TEST, "2d353a69-afa0-44a2-9028-211771d748ae"),
+                                       entry(PROD, "")));
+                put(USN, Map.ofEntries(entry(SANDBOX, ""),
+                                       entry(DEVELOP, "702c4fbe-d51a-4d20-aec8-50beb813ff36"),
+                                       entry(TEST, ""),
+                                       entry(PROD, "")));
+                put(NIKU, Map.ofEntries(entry(SANDBOX, ""),
+                                        entry(DEVELOP, "11c1a22c-6b1b-4463-b74e-e20cd13d7243"),
+                                        entry(TEST, ""),
+                                        entry(PROD, "")));
+                put(NILU, Map.ofEntries(entry(SANDBOX, ""),
+                                        entry(DEVELOP, "68e24208-5840-45a1-903c-44ebb3afccc2"),
+                                        entry(TEST, "31ac9694-3e2e-4424-bd4c-b03e950335e2"),
+                                        entry(PROD, "")));
+                put(NGU, Map.ofEntries(entry(SANDBOX, ""),
+                                       entry(DEVELOP, "4ff971c0-071b-421e-8566-1c0899f3b26c"),
+                                       entry(TEST, ""),
+                                       entry(PROD, "")));
+                put(UIT, Map.ofEntries(entry(SANDBOX, ""),
+                                       entry(DEVELOP, "2d35d439-055d-40e5-94de-a9ec28493835"),
+                                       entry(TEST, "acf2bd2e-a721-4f0f-91ca-3c7f46c0e375"),
+                                       entry(PROD, "")));
+                put(UIO, Map.ofEntries(entry(SANDBOX, ""),
+                                       entry(DEVELOP, "8db4a8bd-3db5-420b-a2e4-fc17a489aa6d"),
+                                       entry(TEST, ""),
+                                       entry(PROD, "")));
+        }};
 
     private static final String SANDBOX_URI = "https://api.sandbox.nva.aws.unit.no/customer/";
     private static final String DEVELOP_URI = "https://api.dev.nva.aws.unit.no/customer/";

--- a/src/main/java/no/sikt/nva/scrapers/CustomerMapper.java
+++ b/src/main/java/no/sikt/nva/scrapers/CustomerMapper.java
@@ -59,70 +59,65 @@ public class CustomerMapper {
     public static final String DEVELOP = "dev";
     public static final String TEST = "test";
     public static final String PROD = "prod";
+    public static final String NB = "nb";
+    public static final String NFORSK = "nforsk";
     private static final Map<String, Map<String, String>> CUSTOMER_MAP = Map.ofEntries(
-            entry(NUPI, Map.ofEntries(
+        entry(NUPI, Map.ofEntries(
                     entry(SANDBOX, ""),
                     entry(DEVELOP, "8d11f0f0-d414-4564-9250-298c06ef5c87"),
                     entry(TEST, "122d33a7-1844-466a-926b-333eeff42a93"),
-                    entry(PROD, "")
-            )),
-            entry(OMSORGSFORSKNING, Map.ofEntries(
+                    entry(PROD, ""))),
+        entry(OMSORGSFORSKNING, Map.ofEntries(
                     entry(SANDBOX, ""),
                     entry(DEVELOP, ""),
                     entry(TEST, ""),
-                    entry(PROD, "")
-            )),
-            entry(INN, Map.ofEntries(
+                    entry(PROD, ""))),
+        entry(INN, Map.ofEntries(
                     entry(SANDBOX, ""),
                     entry(DEVELOP, "023f1608-1baa-4d5a-8acc-80d329bddd74"),
                     entry(TEST, "df2a796f-3eef-45dc-a39d-51b21989285a"),
-                    entry(PROD, "")
-            )),
-            entry(BI, Map.ofEntries(
+                    entry(PROD, ""))),
+        entry(BI, Map.ofEntries(
                     entry(SANDBOX, ""),
                     entry(DEVELOP, "a49a2deb-f782-4ab1-b2ab-97745bc14b3d"),
                     entry(TEST, "e9fb0c5d-1589-4d6f-932f-b312e50daa8f"),
-                    entry(PROD, "")
-            )),
-            entry(VID, Map.ofEntries(
+                    entry(PROD, ""))),
+        entry(VID, Map.ofEntries(
                     entry(SANDBOX, ""),
                     entry(DEVELOP, "58d2d14c-ff23-4aa0-94f1-b53190fd020a"),
                     entry(TEST, "9b17e692-6690-41a2-923b-b7ac0d7a1522"),
-                    entry(PROD, "")
-            )),
-            entry(BANENOR, Map.ofEntries(
+                    entry(PROD, ""))),
+        entry(BANENOR, Map.ofEntries(
                     entry(SANDBOX, ""),
                     entry(DEVELOP, ""),
                     entry(TEST, ""),
-                    entry(PROD, "")
-            )),
-            entry(RA, Map.ofEntries(
+                    entry(PROD, ""))),
+        entry(RA, Map.ofEntries(
                     entry(SANDBOX, "b3435185-929a-4842-96ee-4243f4c9078c"),
                     entry(DEVELOP, "e974d7d1-50b5-47c0-ad7e-7135a2d47555"),
                     entry(TEST, "434ed8ed-f302-409f-9943-8886320550a3"),
-                    entry(PROD, "")
-            )),
-            entry(NORGES_BANK, Map.ofEntries(
+                    entry(PROD, ""))),
+        entry(NORGES_BANK, Map.ofEntries(
                     entry(SANDBOX, ""),
                     entry(DEVELOP, "9d02e866-aeba-466d-993a-b519c664d38c"),
                     entry(TEST, "2d37e9a9-dc70-4c30-bdb6-c7724eb7f0c3"),
                     entry(PROD, ""))),
-            entry(NVE, Map.ofEntries(entry(SANDBOX, "5eb7ca32-0e6b-4819-b794-c31a4b16ea6b"),
+        entry(NVE, Map.ofEntries(entry(SANDBOX, "5eb7ca32-0e6b-4819-b794-c31a4b16ea6b"),
                     entry(DEVELOP, "b4497570-2903-49a2-9c2a-d6ab8b0eacc2"),
                     entry(TEST, ""),
                     entry(PROD, "4ba5f697-2056-4292-b0a3-f81ccf21ea22"))),
 
-            entry(KRUS, Map.ofEntries(entry(SANDBOX, "6b5e1238-7a05-11ed-a1eb-0242ac120002"),
+        entry(KRUS, Map.ofEntries(entry(SANDBOX, "6b5e1238-7a05-11ed-a1eb-0242ac120002"),
                     entry(DEVELOP, "a768727e-4ecb-41c1-a616-1fec000cac1c"),
                     entry(TEST, ""),
                     entry(PROD, ""))),
 
-            entry(KRISTIANIA, Map.ofEntries(entry(SANDBOX, "8fb3c2f4-da97-4eb1-be65-307c86b993ee"),
+        entry(KRISTIANIA, Map.ofEntries(entry(SANDBOX, "8fb3c2f4-da97-4eb1-be65-307c86b993ee"),
                     entry(DEVELOP, "ca57b418-f837-40fd-af5c-5a6ba14abd7e"),
                     entry(TEST, "c1d7b72b-3319-4a1f-a365-c04ddb729b6f"),
                     entry(PROD, "05329411-0aa7-4c68-8cc6-5875f0d58f8c"))),
 
-            entry(FHS, Map.ofEntries(entry(SANDBOX, ""),
+        entry(FHS, Map.ofEntries(entry(SANDBOX, ""),
                     entry(DEVELOP, "290bb113-cf83-4917-8a07-463b4eca057b"),
                     entry(TEST, "ba0b80e8-ca87-4b8f-bf2a-6d00188ad707"),
                     entry(PROD, ""))),
@@ -266,10 +261,18 @@ public class CustomerMapper {
                                       entry(DEVELOP, "2c1deeca-c0fc-487e-93c8-9f0cf4fae490"),
                                       entry(TEST, "95100df5-b46b-41c9-a87a-9a2efc58716e"),
                                       entry(PROD, ""))),
-            entry(FFI, Map.ofEntries(entry(SANDBOX, ""),
-                                          entry(DEVELOP, "04939e4d-105e-4d3c-b945-7d482d4f18d5"),
-                                          entry(TEST, ""),
-                                          entry(PROD, "")))
+        entry(FFI, Map.ofEntries(entry(SANDBOX, ""),
+                                 entry(DEVELOP, "04939e4d-105e-4d3c-b945-7d482d4f18d5"),
+                                 entry(TEST, ""),
+                                 entry(PROD, ""))),
+        entry(NB, Map.ofEntries(entry(SANDBOX, ""),
+                                entry(DEVELOP, "9fde89c7-baea-4ac1-ad52-97d4dee0e6da"),
+                                entry(TEST, ""),
+                                entry(PROD, ""))),
+        entry(NFORSK, Map.ofEntries(entry(SANDBOX, ""),
+                                    entry(DEVELOP, "5196161e-c952-4b36-9125-3e9746ee338d"),
+                                    entry(TEST, ""),
+                                    entry(PROD, "")))
 
     );
 

--- a/src/main/java/no/sikt/nva/scrapers/ResourceOwnerMapper.java
+++ b/src/main/java/no/sikt/nva/scrapers/ResourceOwnerMapper.java
@@ -4,12 +4,14 @@ import static java.util.Map.entry;
 import static no.sikt.nva.scrapers.CustomerMapper.AHO;
 import static no.sikt.nva.scrapers.CustomerMapper.BI;
 import static no.sikt.nva.scrapers.CustomerMapper.BORA;
+import static no.sikt.nva.scrapers.CustomerMapper.CICERO;
 import static no.sikt.nva.scrapers.CustomerMapper.CMI;
 import static no.sikt.nva.scrapers.CustomerMapper.DMMH;
 import static no.sikt.nva.scrapers.CustomerMapper.FAFO;
 import static no.sikt.nva.scrapers.CustomerMapper.FDIR;
 import static no.sikt.nva.scrapers.CustomerMapper.FFI;
 import static no.sikt.nva.scrapers.CustomerMapper.FHS;
+import static no.sikt.nva.scrapers.CustomerMapper.FNI;
 import static no.sikt.nva.scrapers.CustomerMapper.HIMOLDE;
 import static no.sikt.nva.scrapers.CustomerMapper.HIOF;
 import static no.sikt.nva.scrapers.CustomerMapper.HIVOLDA;
@@ -25,13 +27,24 @@ import static no.sikt.nva.scrapers.CustomerMapper.NASJONALMUSEET;
 import static no.sikt.nva.scrapers.CustomerMapper.NB;
 import static no.sikt.nva.scrapers.CustomerMapper.NFORSK;
 import static no.sikt.nva.scrapers.CustomerMapper.NGI;
+import static no.sikt.nva.scrapers.CustomerMapper.NGU;
 import static no.sikt.nva.scrapers.CustomerMapper.NHH;
 import static no.sikt.nva.scrapers.CustomerMapper.NIBIO;
 import static no.sikt.nva.scrapers.CustomerMapper.NIFU;
 import static no.sikt.nva.scrapers.CustomerMapper.NIH;
+import static no.sikt.nva.scrapers.CustomerMapper.NIKU;
+import static no.sikt.nva.scrapers.CustomerMapper.NILU;
+import static no.sikt.nva.scrapers.CustomerMapper.NINA;
 import static no.sikt.nva.scrapers.CustomerMapper.NIVA;
+import static no.sikt.nva.scrapers.CustomerMapper.NLA;
+import static no.sikt.nva.scrapers.CustomerMapper.NMBU;
+import static no.sikt.nva.scrapers.CustomerMapper.NMH;
+import static no.sikt.nva.scrapers.CustomerMapper.NOFIMA;
+import static no.sikt.nva.scrapers.CustomerMapper.NORCERESEARCH;
 import static no.sikt.nva.scrapers.CustomerMapper.NORD;
 import static no.sikt.nva.scrapers.CustomerMapper.NORGES_BANK;
+import static no.sikt.nva.scrapers.CustomerMapper.NORSKFOLKEMUSEUM;
+import static no.sikt.nva.scrapers.CustomerMapper.NPOLAR;
 import static no.sikt.nva.scrapers.CustomerMapper.NR;
 import static no.sikt.nva.scrapers.CustomerMapper.NTNU;
 import static no.sikt.nva.scrapers.CustomerMapper.NUPI;
@@ -39,12 +52,22 @@ import static no.sikt.nva.scrapers.CustomerMapper.NVE;
 import static no.sikt.nva.scrapers.CustomerMapper.ODA;
 import static no.sikt.nva.scrapers.CustomerMapper.RA;
 import static no.sikt.nva.scrapers.CustomerMapper.PHS;
+import static no.sikt.nva.scrapers.CustomerMapper.RURALIS;
+import static no.sikt.nva.scrapers.CustomerMapper.SAMAS;
 import static no.sikt.nva.scrapers.CustomerMapper.SAMFORSK;
+import static no.sikt.nva.scrapers.CustomerMapper.SAMFUNNSFORSKNING;
+import static no.sikt.nva.scrapers.CustomerMapper.SIHF;
+import static no.sikt.nva.scrapers.CustomerMapper.SINTEF;
+import static no.sikt.nva.scrapers.CustomerMapper.SSB;
 import static no.sikt.nva.scrapers.CustomerMapper.STAMI;
 import static no.sikt.nva.scrapers.CustomerMapper.STATPED;
 import static no.sikt.nva.scrapers.CustomerMapper.STEINERHOYSKOLEN;
 import static no.sikt.nva.scrapers.CustomerMapper.UIA;
+import static no.sikt.nva.scrapers.CustomerMapper.UIO;
+import static no.sikt.nva.scrapers.CustomerMapper.UIS;
+import static no.sikt.nva.scrapers.CustomerMapper.UIT;
 import static no.sikt.nva.scrapers.CustomerMapper.UNIT;
+import static no.sikt.nva.scrapers.CustomerMapper.USN;
 import static no.sikt.nva.scrapers.CustomerMapper.VEGVESEN;
 import static no.sikt.nva.scrapers.CustomerMapper.VID;
 import static no.sikt.nva.scrapers.CustomerMapper.VETINST;
@@ -54,9 +77,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
+import java.util.concurrent.ConcurrentHashMap;
 import no.sikt.nva.brage.migration.common.model.record.ResourceOwner;
 
-@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+@SuppressWarnings({"PMD.AvoidUsingHardCodedIP", "PMD.DoubleBraceInitialization"})
 public class ResourceOwnerMapper {
 
     public static final String SANDBOX = "sandbox";
@@ -129,7 +153,7 @@ public class ResourceOwnerMapper {
     public static final String KHIO_CRISTIN_IDENTIFIER = "260.0.0.0";
     public static final String LDH_OWNER_VALUE = "ldh@230.0.0.0";
     public static final String LDH_CRISTIN_IDENTIFIER = "230.0.0.0";
-    public static final String MF_OWNER_VALUE = "ldh@190.0.0.0";
+    public static final String MF_OWNER_VALUE = "mf@190.0.0.0";
     public static final String MF_CRISTIN_IDENTIFIER = "190.0.0.0";
     public static final String NIFU_OWNER_VALUE = "nifu@7463.0.0.0";
     public static final String NIFU_CRISTIN_IDENTIFIER = "7463.0.0.0";
@@ -163,103 +187,196 @@ public class ResourceOwnerMapper {
     private static final String NB_OWNER_VALUE = "nb@5931.0.0.0";
     private static final String NFORSK_CRISTIN_IDENTIFIER = "7446.0.0.0";
     private static final String NFORSK_OWNER_VALUE = "nforsk@7446.0.0.0";
+    private static final String CICERO_CRISTIN_IDENTIFIER = "7475.0.0.0";
+    private static final String CICERO_OWNER_VALUE = "cicero@7475.0.0.0";
+    private static final String FNI_OWNER_VALUE = "fni@7430.0.0.0";
+    private static final String FNI_CRISTIN_IDENTIFIER = "7430.0.0.0";
+    private static final String NLA_OWNER_VALUE = "nla@54.0.0.0";
+    private static final String NLA_CRISTIN_IDENTIFIER = "54.0.0.0";
+    private static final String NINA_CRISTIN_IDENTIFIER = "7511.0.0.0";
+    private static final String NINA_OWNER_VALUE = "nina@7511.0.0.0";
+    private static final String NMBU_OWNER_VALUE = "nbmu@192.0.0.0";
+    private static final String NMBU_CRISTIN_IDENTIFIER = "192.0.0.0";
+    private static final String NMH_CRISTIN_IDENTIFIER = "178.0.0.0";
+    private static final String NMH_OWNER_VALUE = "nmh@178.0.0.0";
+    private static final String NOFIMA_CRISTIN_IDENTIFIER = "7543.0.0.0";
+    private static final String NOFIMA_OWNER_VALUE = "nofima@7543.0.0.0";
+    private static final String NORSERESEARCH_OWNER_VALUE = "norceresearch@2057.0.0.0";
+    private static final String NORCERESEARCH_CRISTIN_IDENTIFIER = "2057.0.0.0";
+    private static final String NORSKFOLKEMUSEUM_CRISTIN_IDENTIFIER = "1302.0.0.0";
+    private static final String NORSKFOLKEMUSEUM_OWNER_VALUE = "norskfolkemuseum@1302.0.0.0";
+    private static final String NPOLAR_CRISTIN_IDENTIFIER = "7466.0.0.0";
+    private static final String NPOLAR_OWNER_VALUE = "npolar@7466.0.0.0";
+    private static final String RURALIS_CRISTIN_IDENTIFIER = "7501.0.0.0";
+    private static final String RURALIS_OWNER_VALUE = "ruralis@7501.0.0.0";
+    private static final String SAMAS_CRISTIN_IDENTIFIER = "231.0.0.0";
+    private static final String SAMAS_OWNER_VALUE = "samas@231.0.0.0";
+    private static final String SAMFUNNSFORSKNING_CRISTIN_IDENTIFIER = "7437.0.0.0";
+    private static final String SAMFUNNSFORSKNING_OWNER_VALUE = "samfunnsforskning@7437.0.0.0";
+    private static final String SIHF_CRISTIN_IDENTIFIER = "1991.0.0.0";
+    private static final String SIHF_OWNER_VALUE = "sihf@1991.0.0.0";
+    private static final String SINTEF_CRISTIN_IDENTIFIER = "7401.0.0.0";
+    private static final String SINTEF_OWNER_VALUE = "sintef@7401.0.0.0";
+    private static final String SSB_CRISTIN_IDENTIFIER = "5932.0.0.0";
+    private static final String SSB_OWNER_VALUE = "ssb@5932.0.0.0";
+    private static final String UIS_CRISTIN_IDENTIFIER = "217.0.0.0";
+    private static final String UIS_OWNER_VALUE = "uis@217.0.0.0";
+    private static final String USN_CRISTIN_IDENTIFIER = "222.0.0.0";
+    private static final String USN_OWNER_VALUE = "usn@222.0.0.0";
+    private static final String NIKU_OWNER_VALUE = "niku@7530.0.0.0";
+    private static final String NIKU_CRISTIN_IDENTIFIER = "7530.0.0.0";
+    private static final String NILU_CRISTIN_IDENTIFIER = "7460.0.0.0";
+    private static final String NILU_OWNER_VALUE = "nilu@7460.0.0.0";
+    private static final String NGU_CRISTIN_IDENTIFIER = "7452.0.0.0";
+    private static final String NGU_OWNER_VALUE = "ngu@7452.0.0.0";
+    private static final String UIT_CRISTIN_IDENTIFIER = "186.0.0.0";
+    private static final String UIT_OWNER_VALUE = "uit@186.0.0.0";
+    private static final String UIO_CRISTIN_IDENTIFIER = "185.90.0.0";
+    private static final String UIO_OWNER_VALUE = "uio@185.90.0.0";
     @SuppressWarnings("PMD.UseConcurrentHashMap")
-    private static final Map<String, Map<String, String>> RESOURCE_OWNER_MAP = Map.ofEntries(
-            entry(NORGES_BANK, Map.ofEntries(entry(OWNER_VALUE, NORGES_BANK_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, NORGES_BANK_CRISTIN_IDENTIFIER))),
-            entry(RA, Map.ofEntries(entry(OWNER_VALUE, RA_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, RA_CRISTIN_IDENTIFIER))),
-            entry(VID, Map.ofEntries(entry(OWNER_VALUE, VID_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, VID_CRISTIN_IDENTIFIER))),
-            entry(BI, Map.ofEntries(entry(OWNER_VALUE, BI_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, BI_CRISTIN_IDENTIFIER))),
-            entry(INN, Map.ofEntries(entry(OWNER_VALUE, INN_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, INN_CRISTIN_IDENTIFIER))),
-            entry(NUPI, Map.ofEntries(entry(OWNER_VALUE, NUPI_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, NUPI_CRISTIN_IDENTIFIER))),
-            entry(NVE, Map.ofEntries(entry(OWNER_VALUE, NVE_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, NVE_CRISTIN_IDENTIFIER))),
-            entry(KRUS, Map.ofEntries(entry(OWNER_VALUE, KRUS_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, KRUS_CRISTIN_IDENTIFIER))),
-            entry(KRISTIANIA, Map.ofEntries(entry(OWNER_VALUE, KRISTIANIA_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, KRISTIANIA_CRISTIN_IDENTIFIER))),
-            entry(FHS, Map.ofEntries(entry(OWNER_VALUE, FHS_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, FHS_CRISTIN_IDENTIFIER))),
-            entry(HIOF, Map.ofEntries(entry(OWNER_VALUE, HIOF_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, HIOF_CRISTIN_IDENTIFIER))),
-            entry(NGI, Map.ofEntries(entry(OWNER_VALUE, NGI_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, NGI_CRISTIN_IDENTIFIER))),
-            entry(NIBIO, Map.ofEntries(entry(OWNER_VALUE, NIBIO_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, NIBIO_CRISTIN_IDENTIFIER))),
-            entry(NIH, Map.ofEntries(entry(OWNER_VALUE, NIH_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, NIH_CRISTIN_IDENTIFIER))),
-            entry(NTNU, Map.ofEntries(entry(OWNER_VALUE, NTNU_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, NTNU_CRISTIN_IDENTIFIER))),
-            entry(NR, Map.ofEntries(entry(OWNER_VALUE, NR_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, NR_CRISTIN_IDENTIFIER))),
-            entry(SAMFORSK, Map.ofEntries(entry(OWNER_VALUE, SAMFORSK_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, SAMFORSK_CRISTIN_IDENTIFIER))),
-            entry(CMI, Map.ofEntries(entry(OWNER_VALUE, CMI_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, CMI_CRISTIN_IDENTIFIER))),
-            entry(DMMH, Map.ofEntries(entry(OWNER_VALUE, DMMH_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, DMMH_CRISTIN_IDENTIFIER))),
-            entry(FAFO, Map.ofEntries(entry(OWNER_VALUE, FAFO_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, FAFO_CRISTIN_IDENTIFIER))),
-            entry(FDIR, Map.ofEntries(entry(OWNER_VALUE, FDIR_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, FDIR_CRISTIN_IDENTIFIER))),
-            entry(UIA, Map.ofEntries(entry(OWNER_VALUE, UIA_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, UIA_CRISTIN_IDENTIFIER))),
-            entry(NORD, Map.ofEntries(entry(OWNER_VALUE, NORD_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, NORD_CRISTIN_IDENTIFIER))),
-            entry(ODA, Map.ofEntries(entry(OWNER_VALUE, ODA_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, ODA_CRISTIN_IDENTIFIER))),
-            entry(HIMOLDE, Map.ofEntries(entry(OWNER_VALUE, HIMOLDE_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, HIMOLDE_CRISTIN_IDENTIFIER))),
-            entry(HIVOLDA, Map.ofEntries(entry(OWNER_VALUE, HIVOLDA_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, HIVOLDA_CRISTIN_IDENTIFIER))),
-            entry(HVLOPEN, Map.ofEntries(entry(OWNER_VALUE, HVLOPEN_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, HVLOPEN_CRISTIN_IDENTIFIER))),
-            entry(NHH, Map.ofEntries(entry(OWNER_VALUE, NHH_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, NHH_CRISTIN_IDENTIFIER))),
-            entry(BORA, Map.ofEntries(entry(OWNER_VALUE, BORA_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, BORA_CRISTIN_IDENTIFIER))),
-            entry(AHO, Map.ofEntries(entry(OWNER_VALUE, AHO_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, AHO_CRISTIN_IDENTIFIER))),
-            entry(IFE, Map.ofEntries(entry(OWNER_VALUE, IFE_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, IFE_CRISTIN_IDENTIFIER))),
-            entry(KHIO, Map.ofEntries(entry(OWNER_VALUE, KHIO_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, KHIO_CRISTIN_IDENTIFIER))),
-            entry(LDH, Map.ofEntries(entry(OWNER_VALUE, LDH_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, LDH_CRISTIN_IDENTIFIER))),
-            entry(MF, Map.ofEntries(entry(OWNER_VALUE, MF_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, MF_CRISTIN_IDENTIFIER))),
-            entry(NIFU, Map.ofEntries(entry(OWNER_VALUE, NIFU_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, NIFU_CRISTIN_IDENTIFIER))),
-            entry(NIVA, Map.ofEntries(entry(OWNER_VALUE, NIVA_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, NIVA_CRISTIN_IDENTIFIER))),
-            entry(PHS, Map.ofEntries(entry(OWNER_VALUE, PHS_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, PHS_CRISTIN_IDENTIFIER))),
-            entry(STAMI, Map.ofEntries(entry(OWNER_VALUE, STAMI_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, STAMI_CRISTIN_IDENTIFIER))),
-            entry(STEINERHOYSKOLEN, Map.ofEntries(entry(OWNER_VALUE, STEINERHOYSKOLEN_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, STEINERHOYSKOLEN_CRISTIN_IDENTIFIER))),
-            entry(VETINST, Map.ofEntries(entry(OWNER_VALUE, VETINST_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, VETINST_CRISTIN_IDENTIFIER))),
-            entry(NASJONALMUSEET, Map.ofEntries(entry(OWNER_VALUE, NASJONALMUSEET_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, NASJONALMUSEET_CRISTIN_IDENTIFIER))),
-            entry(UNIT, Map.ofEntries(entry(OWNER_VALUE, UNIT_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, UNIT_CRISTIN_IDENTIFIER))),
-            entry(STATPED, Map.ofEntries(entry(OWNER_VALUE, STATPED_OWNER_VALUE),
-                    entry(CRISTIN_IDENTIFIER, STATPED_CRISTIN_IDENTIFIER))),
-            entry(VEGVESEN, Map.ofEntries(entry(OWNER_VALUE, VEGVESEN_OWNER_VALUE),
-                                         entry(CRISTIN_IDENTIFIER, VEGVESEN_CRISTIN_IDENTIFIER))),
-            entry(FFI, Map.ofEntries(entry(OWNER_VALUE, FFI_OWNER_VALUE),
-                                          entry(CRISTIN_IDENTIFIER, FFI_CRISTIN_IDENTIFIER))),
-            entry(NB, Map.ofEntries(entry(OWNER_VALUE, NB_OWNER_VALUE),
-                                     entry(CRISTIN_IDENTIFIER, NB_CRISTIN_IDENTIFIER))),
-            entry(NFORSK, Map.ofEntries(entry(OWNER_VALUE, NFORSK_OWNER_VALUE),
-                                    entry(CRISTIN_IDENTIFIER, NFORSK_CRISTIN_IDENTIFIER)))
-    );
+    private static final Map<String, Map<String, String>> RESOURCE_OWNER_MAP = new ConcurrentHashMap<>()
+    {{
+            put(NORGES_BANK, Map.ofEntries(entry(OWNER_VALUE, NORGES_BANK_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NORGES_BANK_CRISTIN_IDENTIFIER)));
+            put(RA, Map.ofEntries(entry(OWNER_VALUE, RA_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, RA_CRISTIN_IDENTIFIER)));
+            put(VID, Map.ofEntries(entry(OWNER_VALUE, VID_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, VID_CRISTIN_IDENTIFIER)));
+            put(BI, Map.ofEntries(entry(OWNER_VALUE, BI_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, BI_CRISTIN_IDENTIFIER)));
+            put(INN, Map.ofEntries(entry(OWNER_VALUE, INN_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, INN_CRISTIN_IDENTIFIER)));
+            put(NUPI, Map.ofEntries(entry(OWNER_VALUE, NUPI_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NUPI_CRISTIN_IDENTIFIER)));
+            put(NVE, Map.ofEntries(entry(OWNER_VALUE, NVE_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NVE_CRISTIN_IDENTIFIER)));
+            put(KRUS, Map.ofEntries(entry(OWNER_VALUE, KRUS_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, KRUS_CRISTIN_IDENTIFIER)));
+            put(KRISTIANIA, Map.ofEntries(entry(OWNER_VALUE, KRISTIANIA_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, KRISTIANIA_CRISTIN_IDENTIFIER)));
+            put(FHS, Map.ofEntries(entry(OWNER_VALUE, FHS_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, FHS_CRISTIN_IDENTIFIER)));
+            put(HIOF, Map.ofEntries(entry(OWNER_VALUE, HIOF_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, HIOF_CRISTIN_IDENTIFIER)));
+            put(NGI, Map.ofEntries(entry(OWNER_VALUE, NGI_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NGI_CRISTIN_IDENTIFIER)));
+            put(NIBIO, Map.ofEntries(entry(OWNER_VALUE, NIBIO_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NIBIO_CRISTIN_IDENTIFIER)));
+            put(NIH, Map.ofEntries(entry(OWNER_VALUE, NIH_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NIH_CRISTIN_IDENTIFIER)));
+            put(NTNU, Map.ofEntries(entry(OWNER_VALUE, NTNU_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NTNU_CRISTIN_IDENTIFIER)));
+            put(NR, Map.ofEntries(entry(OWNER_VALUE, NR_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NR_CRISTIN_IDENTIFIER)));
+            put(SAMFORSK, Map.ofEntries(entry(OWNER_VALUE, SAMFORSK_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, SAMFORSK_CRISTIN_IDENTIFIER)));
+            put(CMI, Map.ofEntries(entry(OWNER_VALUE, CMI_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, CMI_CRISTIN_IDENTIFIER)));
+            put(DMMH, Map.ofEntries(entry(OWNER_VALUE, DMMH_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, DMMH_CRISTIN_IDENTIFIER)));
+            put(FAFO, Map.ofEntries(entry(OWNER_VALUE, FAFO_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, FAFO_CRISTIN_IDENTIFIER)));
+            put(FDIR, Map.ofEntries(entry(OWNER_VALUE, FDIR_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, FDIR_CRISTIN_IDENTIFIER)));
+            put(UIA, Map.ofEntries(entry(OWNER_VALUE, UIA_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, UIA_CRISTIN_IDENTIFIER)));
+            put(NORD, Map.ofEntries(entry(OWNER_VALUE, NORD_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NORD_CRISTIN_IDENTIFIER)));
+            put(ODA, Map.ofEntries(entry(OWNER_VALUE, ODA_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, ODA_CRISTIN_IDENTIFIER)));
+            put(HIMOLDE, Map.ofEntries(entry(OWNER_VALUE, HIMOLDE_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, HIMOLDE_CRISTIN_IDENTIFIER)));
+            put(HIVOLDA, Map.ofEntries(entry(OWNER_VALUE, HIVOLDA_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, HIVOLDA_CRISTIN_IDENTIFIER)));
+            put(HVLOPEN, Map.ofEntries(entry(OWNER_VALUE, HVLOPEN_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, HVLOPEN_CRISTIN_IDENTIFIER)));
+            put(NHH, Map.ofEntries(entry(OWNER_VALUE, NHH_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NHH_CRISTIN_IDENTIFIER)));
+            put(BORA, Map.ofEntries(entry(OWNER_VALUE, BORA_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, BORA_CRISTIN_IDENTIFIER)));
+            put(AHO, Map.ofEntries(entry(OWNER_VALUE, AHO_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, AHO_CRISTIN_IDENTIFIER)));
+            put(IFE, Map.ofEntries(entry(OWNER_VALUE, IFE_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, IFE_CRISTIN_IDENTIFIER)));
+            put(KHIO, Map.ofEntries(entry(OWNER_VALUE, KHIO_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, KHIO_CRISTIN_IDENTIFIER)));
+            put(LDH, Map.ofEntries(entry(OWNER_VALUE, LDH_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, LDH_CRISTIN_IDENTIFIER)));
+            put(MF, Map.ofEntries(entry(OWNER_VALUE, MF_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, MF_CRISTIN_IDENTIFIER)));
+            put(NIFU, Map.ofEntries(entry(OWNER_VALUE, NIFU_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NIFU_CRISTIN_IDENTIFIER)));
+            put(NIVA, Map.ofEntries(entry(OWNER_VALUE, NIVA_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NIVA_CRISTIN_IDENTIFIER)));
+            put(PHS, Map.ofEntries(entry(OWNER_VALUE, PHS_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, PHS_CRISTIN_IDENTIFIER)));
+            put(STAMI, Map.ofEntries(entry(OWNER_VALUE, STAMI_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, STAMI_CRISTIN_IDENTIFIER)));
+            put(STEINERHOYSKOLEN, Map.ofEntries(entry(OWNER_VALUE, STEINERHOYSKOLEN_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, STEINERHOYSKOLEN_CRISTIN_IDENTIFIER)));
+            put(VETINST, Map.ofEntries(entry(OWNER_VALUE, VETINST_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, VETINST_CRISTIN_IDENTIFIER)));
+            put(NASJONALMUSEET, Map.ofEntries(entry(OWNER_VALUE, NASJONALMUSEET_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NASJONALMUSEET_CRISTIN_IDENTIFIER)));
+            put(UNIT, Map.ofEntries(entry(OWNER_VALUE, UNIT_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, UNIT_CRISTIN_IDENTIFIER)));
+            put(STATPED, Map.ofEntries(entry(OWNER_VALUE, STATPED_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, STATPED_CRISTIN_IDENTIFIER)));
+            put(VEGVESEN, Map.ofEntries(entry(OWNER_VALUE, VEGVESEN_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, VEGVESEN_CRISTIN_IDENTIFIER)));
+            put(FFI, Map.ofEntries(entry(OWNER_VALUE, FFI_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, FFI_CRISTIN_IDENTIFIER)));
+            put(NB, Map.ofEntries(entry(OWNER_VALUE, NB_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NB_CRISTIN_IDENTIFIER)));
+            put(NFORSK, Map.ofEntries(entry(OWNER_VALUE, NFORSK_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NFORSK_CRISTIN_IDENTIFIER)));
+            put(CICERO, Map.ofEntries(entry(OWNER_VALUE, CICERO_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, CICERO_CRISTIN_IDENTIFIER)));
+            put(FNI, Map.ofEntries(entry(OWNER_VALUE, FNI_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, FNI_CRISTIN_IDENTIFIER)));
+            put(NLA, Map.ofEntries(entry(OWNER_VALUE, NLA_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NLA_CRISTIN_IDENTIFIER)));
+            put(NINA, Map.ofEntries(entry(OWNER_VALUE, NINA_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NINA_CRISTIN_IDENTIFIER)));
+            put(NMBU, Map.ofEntries(entry(OWNER_VALUE, NMBU_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NMBU_CRISTIN_IDENTIFIER)));
+            put(NMH, Map.ofEntries(entry(OWNER_VALUE, NMH_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NMH_CRISTIN_IDENTIFIER)));
+            put(NOFIMA, Map.ofEntries(entry(OWNER_VALUE, NOFIMA_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NOFIMA_CRISTIN_IDENTIFIER)));
+            put(NORCERESEARCH, Map.ofEntries(entry(OWNER_VALUE, NORSERESEARCH_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NORCERESEARCH_CRISTIN_IDENTIFIER)));
+            put(NORSKFOLKEMUSEUM, Map.ofEntries(entry(OWNER_VALUE, NORSKFOLKEMUSEUM_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NORSKFOLKEMUSEUM_CRISTIN_IDENTIFIER)));
+            put(NPOLAR, Map.ofEntries(entry(OWNER_VALUE, NPOLAR_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NPOLAR_CRISTIN_IDENTIFIER)));
+            put(RURALIS, Map.ofEntries(entry(OWNER_VALUE, RURALIS_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, RURALIS_CRISTIN_IDENTIFIER)));
+            put(SAMAS, Map.ofEntries(entry(OWNER_VALUE, SAMAS_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, SAMAS_CRISTIN_IDENTIFIER)));
+            put(SAMFUNNSFORSKNING, Map.ofEntries(entry(OWNER_VALUE, SAMFUNNSFORSKNING_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, SAMFUNNSFORSKNING_CRISTIN_IDENTIFIER)));
+            put(SIHF, Map.ofEntries(entry(OWNER_VALUE, SIHF_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, SIHF_CRISTIN_IDENTIFIER)));
+            put(SINTEF, Map.ofEntries(entry(OWNER_VALUE, SINTEF_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, SINTEF_CRISTIN_IDENTIFIER)));
+            put(SSB, Map.ofEntries(entry(OWNER_VALUE, SSB_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, SSB_CRISTIN_IDENTIFIER)));
+            put(UIS, Map.ofEntries(entry(OWNER_VALUE, UIS_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, UIS_CRISTIN_IDENTIFIER)));
+            put(USN, Map.ofEntries(entry(OWNER_VALUE, USN_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, USN_CRISTIN_IDENTIFIER)));
+            put(NIKU, Map.ofEntries(entry(OWNER_VALUE, NIKU_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NIKU_CRISTIN_IDENTIFIER)));
+            put(NILU, Map.ofEntries(entry(OWNER_VALUE, NILU_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NILU_CRISTIN_IDENTIFIER)));
+            put(NGU, Map.ofEntries(entry(OWNER_VALUE, NGU_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, NGU_CRISTIN_IDENTIFIER)));
+            put(UIT, Map.ofEntries(entry(OWNER_VALUE, UIT_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, UIT_CRISTIN_IDENTIFIER)));
+            put(UIO, Map.ofEntries(entry(OWNER_VALUE, UIO_OWNER_VALUE),
+            entry(CRISTIN_IDENTIFIER, UIO_CRISTIN_IDENTIFIER)));
+    }};
 
     private static final Map<String, String> ENVIRONMENT_URI_MAP = Map.ofEntries(
             entry(SANDBOX, SANDBOX_URI),

--- a/src/main/java/no/sikt/nva/scrapers/ResourceOwnerMapper.java
+++ b/src/main/java/no/sikt/nva/scrapers/ResourceOwnerMapper.java
@@ -22,6 +22,8 @@ import static no.sikt.nva.scrapers.CustomerMapper.KRUS;
 import static no.sikt.nva.scrapers.CustomerMapper.LDH;
 import static no.sikt.nva.scrapers.CustomerMapper.MF;
 import static no.sikt.nva.scrapers.CustomerMapper.NASJONALMUSEET;
+import static no.sikt.nva.scrapers.CustomerMapper.NB;
+import static no.sikt.nva.scrapers.CustomerMapper.NFORSK;
 import static no.sikt.nva.scrapers.CustomerMapper.NGI;
 import static no.sikt.nva.scrapers.CustomerMapper.NHH;
 import static no.sikt.nva.scrapers.CustomerMapper.NIBIO;
@@ -157,6 +159,10 @@ public class ResourceOwnerMapper {
     public static final String DEVELOP_URI = "https://api.sandbox.nva.aws.unit.no/cristin/organization/";
     public static final String TEST_URI = "https://api.test.nva.aws.unit.no/cristin/organization/";
     public static final String PROD_URI = "https://api.nva.aws.unit.no/cristin/organization/";
+    private static final String NB_CRISTIN_IDENTIFIER = "5931.0.0.0";
+    private static final String NB_OWNER_VALUE = "nb@5931.0.0.0";
+    private static final String NFORSK_CRISTIN_IDENTIFIER = "7446.0.0.0";
+    private static final String NFORSK_OWNER_VALUE = "nforsk@7446.0.0.0";
     @SuppressWarnings("PMD.UseConcurrentHashMap")
     private static final Map<String, Map<String, String>> RESOURCE_OWNER_MAP = Map.ofEntries(
             entry(NORGES_BANK, Map.ofEntries(entry(OWNER_VALUE, NORGES_BANK_OWNER_VALUE),
@@ -248,7 +254,11 @@ public class ResourceOwnerMapper {
             entry(VEGVESEN, Map.ofEntries(entry(OWNER_VALUE, VEGVESEN_OWNER_VALUE),
                                          entry(CRISTIN_IDENTIFIER, VEGVESEN_CRISTIN_IDENTIFIER))),
             entry(FFI, Map.ofEntries(entry(OWNER_VALUE, FFI_OWNER_VALUE),
-                                          entry(CRISTIN_IDENTIFIER, FFI_CRISTIN_IDENTIFIER)))
+                                          entry(CRISTIN_IDENTIFIER, FFI_CRISTIN_IDENTIFIER))),
+            entry(NB, Map.ofEntries(entry(OWNER_VALUE, NB_OWNER_VALUE),
+                                     entry(CRISTIN_IDENTIFIER, NB_CRISTIN_IDENTIFIER))),
+            entry(NFORSK, Map.ofEntries(entry(OWNER_VALUE, NFORSK_OWNER_VALUE),
+                                    entry(CRISTIN_IDENTIFIER, NFORSK_CRISTIN_IDENTIFIER)))
     );
 
     private static final Map<String, String> ENVIRONMENT_URI_MAP = Map.ofEntries(


### PR DESCRIPTION
"Vararg method call with 50+ poly arguments may cause compilation and analysis slowdown"

Instantiating large map using Map<,>() seems to be more efficient than Map.ofEntries() when map size increases 50+ entries