### PR TITLE
removing default lines from embargo file

### DIFF
--- a/src/main/java/no/sikt/nva/BrageMigrationCommand.java
+++ b/src/main/java/no/sikt/nva/BrageMigrationCommand.java
@@ -374,7 +374,7 @@ public class BrageMigrationCommand implements Callable<Integer> {
 
     private Map<String, List<Embargo>> getEmbargoes(String directory) {
         var embargoFile = new File(directory + DEFAULT_EMBARGO_FILE_NAME);
-        return EmbargoScraper.getEmbargoList(embargoFile);
+        return EmbargoScraper.getEmbargoes(embargoFile);
     }
 
     private Map<String, Contributor> getContributors(String directory) {

--- a/src/main/java/no/sikt/nva/scrapers/EmbargoScraper.java
+++ b/src/main/java/no/sikt/nva/scrapers/EmbargoScraper.java
@@ -25,7 +25,7 @@ public final class EmbargoScraper {
     public EmbargoScraper() {
     }
 
-    public static Map<String, List<Embargo>> getEmbargoList(File file) {
+    public static Map<String, List<Embargo>> getEmbargoes(File file) {
         try {
             var contentFileAsString = Files.readString(file.toPath());
             var embargoes = convertStringToEmbargoObjects(contentFileAsString);
@@ -47,14 +47,21 @@ public final class EmbargoScraper {
     }
 
     private static Map<String, List<Embargo>> convertStringToEmbargoObjects(String contentFileAsString) {
-        var listOfStringObjects = Arrays.asList(
-            contentFileAsString.replaceAll(EMPTY_LINE_REGEX, StringUtils.EMPTY_STRING)
-                .replace("|", ";")
-                .split("\n"));
-        var embargoes = listOfStringObjects.stream()
+        var listOfStringObjects = Arrays.asList(contentFileAsString.replaceAll(EMPTY_LINE_REGEX, StringUtils.EMPTY_STRING)
+                                                                    .replace("|", ";")
+                                                                    .split("\n"));
+        var embargoes = removeIgnoredLines(listOfStringObjects).stream()
                             .map(EmbargoScraper::convertToEmbargo)
                             .collect(Collectors.toList());
         return createEmbargoHandleMap(embargoes);
+    }
+
+    private static List<String> removeIgnoredLines(List<String> listOfStringObjects) {
+        var list = new ArrayList<>(listOfStringObjects);
+        list.remove(0);
+        list.remove(0);
+        list.remove(list.size() - 1);
+        return list;
     }
 
     private static Embargo convertToEmbargo(String string) {

--- a/src/test/java/no/sikt/nva/scrapers/EmbargoScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/EmbargoScraperTest.java
@@ -3,6 +3,7 @@ package no.sikt.nva.scrapers;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -30,18 +31,25 @@ public class EmbargoScraperTest {
     public static final String TEST_FILE_LOCATION_V2 = "src/test/resources/FileEmbargoV2.txt";
     public static final String EMBARGO_WITH_DISTANT_DATE_TXT = "src/test/resources/FileEmbargo_with_distant_date.txt";
 
+
+    @Test
+    void shouldIgnoreDefaultRowsOfEmbargoFile() {
+        var actualEmbargos =
+            Objects.requireNonNull(EmbargoScraper.getEmbargoes(new File(TEST_FILE_LOCATION))).get(HANDLE);
+        assertThat(actualEmbargos, hasSize(3) );
+    }
     @Test
     void shouldExtractEmbargoWithPdfFile() {
         var expectedEmbargo = new Embargo(HANDLE, FILENAME, DATE);
         var actualEmbargos =
-            Objects.requireNonNull(EmbargoScraper.getEmbargoList(new File(TEST_FILE_LOCATION))).get(HANDLE);
+            Objects.requireNonNull(EmbargoScraper.getEmbargoes(new File(TEST_FILE_LOCATION))).get(HANDLE);
         assertThat(actualEmbargos, hasItem(expectedEmbargo));
     }
 
     @Test
     void shouldExtractEmbargosWithDifferentDelimiter() {
         var expectedEmbargo = new Embargo(HANDLE, FILENAME, DATE);
-        var actualEmbargo = Objects.requireNonNull(EmbargoScraper.getEmbargoList(new File(TEST_FILE_LOCATION_V2)))
+        var actualEmbargo = Objects.requireNonNull(EmbargoScraper.getEmbargoes(new File(TEST_FILE_LOCATION_V2)))
                                 .get(HANDLE);
         assertThat(actualEmbargo, hasItem(expectedEmbargo));
     }
@@ -49,7 +57,7 @@ public class EmbargoScraperTest {
     @Test
     void shouldLogNonDetectedEmbargos() {
         var appender = LogUtils.getTestingAppenderForRootLogger();
-        var embargos = EmbargoScraper.getEmbargoList(new File(TEST_FILE_LOCATION));
+        var embargos = EmbargoScraper.getEmbargoes(new File(TEST_FILE_LOCATION));
         EmbargoParser.logNonEmbargosDetected(embargos);
         assertThat(appender.getMessages(), containsString("Embargo file not found: "));
     }
@@ -57,7 +65,7 @@ public class EmbargoScraperTest {
     @Test
     void shouldNotLogDetectedEmbargos() {
         var appender = LogUtils.getTestingAppenderForRootLogger();
-        var embargos = EmbargoScraper.getEmbargoList(new File(TEST_FILE_LOCATION));
+        var embargos = EmbargoScraper.getEmbargoes(new File(TEST_FILE_LOCATION));
         var record = new Record();
         record.setId(UriWrapper.fromUri("https://hdl.handle.net/11250/2683076").getUri());
         record.setContentBundle(contentBundleWithFileNameFromEmbargo(
@@ -71,7 +79,7 @@ public class EmbargoScraperTest {
     @Test
     void shouldSetEmbargoOnMultipleContentFilesIfNecessary() {
         var appender = LogUtils.getTestingAppenderForRootLogger();
-        var embargos = EmbargoScraper.getEmbargoList(new File(EMBARGO_WITH_DISTANT_DATE_TXT));
+        var embargos = EmbargoScraper.getEmbargoes(new File(EMBARGO_WITH_DISTANT_DATE_TXT));
         var record = new Record();
         record.setId(UriWrapper.fromUri("https://hdl.handle.net/11250/2683076").getUri());
         record.setContentBundle(contentBundleWithFileNameFromEmbargo(

--- a/src/test/java/no/sikt/nva/scrapers/EmbargoScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/EmbargoScraperTest.java
@@ -29,6 +29,7 @@ public class EmbargoScraperTest {
     public static final String DATE = "2023-10-01";
     public static final String TEST_FILE_LOCATION = "src/test/resources/FileEmbargo.txt";
     public static final String TEST_FILE_LOCATION_V2 = "src/test/resources/FileEmbargoV2.txt";
+    public static final String TEST_FILE_LOCATION_V3 = "src/test/resources/FileEmbargoV3.txt";
     public static final String EMBARGO_WITH_DISTANT_DATE_TXT = "src/test/resources/FileEmbargo_with_distant_date.txt";
 
 
@@ -36,8 +37,19 @@ public class EmbargoScraperTest {
     void shouldIgnoreDefaultRowsOfEmbargoFile() {
         var actualEmbargos =
             Objects.requireNonNull(EmbargoScraper.getEmbargoes(new File(TEST_FILE_LOCATION))).get(HANDLE);
-        assertThat(actualEmbargos, hasSize(3) );
+        assertThat(actualEmbargos, hasSize(3));
     }
+
+    @Test
+    void shouldConvertPrettifiedEmbargoFileToEmbargoes() {
+        var expectedEmbargo = new Embargo(HANDLE, FILENAME, DATE);
+        var actualEmbargos =
+            Objects.requireNonNull(EmbargoScraper.getEmbargoes(new File(TEST_FILE_LOCATION_V3))).get(HANDLE);
+
+        assertThat(actualEmbargos, hasSize(3));
+        assertThat(actualEmbargos, hasItem(expectedEmbargo));
+    }
+
     @Test
     void shouldExtractEmbargoWithPdfFile() {
         var expectedEmbargo = new Embargo(HANDLE, FILENAME, DATE);

--- a/src/test/resources/FileEmbargo.txt
+++ b/src/test/resources/FileEmbargo.txt
@@ -1,3 +1,6 @@
+   concat                |                             text_value                              | start_date
+--------------------------------------+---------------------------------------------------------------------+--------
 https://hdl.handle.net/11250/2683076;Simulated precipitation fields with variance consistent interpolation.pdf;2023-10-01
 https://hdl.handle.net/11250/2683076;Simulated precipitation fields with variance consistent interpolation.pdf.jpg;2023-10-01
 https://hdl.handle.net/11250/2683076;Simulated precipitation fields with variance consistent interpolation.pdf.txt;2023-10-01
+(3 rows)

--- a/src/test/resources/FileEmbargoV2.txt
+++ b/src/test/resources/FileEmbargoV2.txt
@@ -1,3 +1,6 @@
+   concat                |                             text_value                              | start_date
+--------------------------------------+---------------------------------------------------------------------+--------
 https://hdl.handle.net/11250/2683076 | Simulated precipitation fields with variance consistent interpolation.pdf | 2023-10-01
 https://hdl.handle.net/11250/2683076 | Simulated precipitation fields with variance consistent interpolation.pdf.jpg | 2023-10-01
 https://hdl.handle.net/11250/2683076 | Simulated precipitation fields with variance consistent interpolation.pdf.txt | 2023-10-01
+(3 Rows)

--- a/src/test/resources/FileEmbargoV2.txt
+++ b/src/test/resources/FileEmbargoV2.txt
@@ -3,4 +3,4 @@
 https://hdl.handle.net/11250/2683076 | Simulated precipitation fields with variance consistent interpolation.pdf | 2023-10-01
 https://hdl.handle.net/11250/2683076 | Simulated precipitation fields with variance consistent interpolation.pdf.jpg | 2023-10-01
 https://hdl.handle.net/11250/2683076 | Simulated precipitation fields with variance consistent interpolation.pdf.txt | 2023-10-01
-(3 Rows)
+(3 rows)

--- a/src/test/resources/FileEmbargoV3.txt
+++ b/src/test/resources/FileEmbargoV3.txt
@@ -1,0 +1,3 @@
+https://hdl.handle.net/11250/2683076 | Simulated precipitation fields with variance consistent interpolation.pdf | 2023-10-01
+https://hdl.handle.net/11250/2683076 | Simulated precipitation fields with variance consistent interpolation.pdf.jpg | 2023-10-01
+https://hdl.handle.net/11250/2683076 | Simulated precipitation fields with variance consistent interpolation.pdf.txt | 2023-10-01

--- a/src/test/resources/FileEmbargo_with_distant_date.txt
+++ b/src/test/resources/FileEmbargo_with_distant_date.txt
@@ -4,4 +4,4 @@ https://hdl.handle.net/11250/2683076;Simulated precipitation fields with varianc
 https://hdl.handle.net/11250/2683076;Simulated precipitation fields with variance consistent interpolation.pdf.jpg;2023-10-01
 https://hdl.handle.net/11250/2683076;Simulated precipitation fields with variance consistent interpolation.pdf.txt;2023-10-01
 https://hdl.handle.net/11250/2683076;My super secret file.pdf;20230-10-01
-(rows 4)
+(4 rows)

--- a/src/test/resources/FileEmbargo_with_distant_date.txt
+++ b/src/test/resources/FileEmbargo_with_distant_date.txt
@@ -1,4 +1,7 @@
+   concat                |                             text_value                              | start_date
+--------------------------------------+---------------------------------------------------------------------+--------
 https://hdl.handle.net/11250/2683076;Simulated precipitation fields with variance consistent interpolation.pdf;2023-10-01
 https://hdl.handle.net/11250/2683076;Simulated precipitation fields with variance consistent interpolation.pdf.jpg;2023-10-01
 https://hdl.handle.net/11250/2683076;Simulated precipitation fields with variance consistent interpolation.pdf.txt;2023-10-01
 https://hdl.handle.net/11250/2683076;My super secret file.pdf;20230-10-01
+(rows 4)

--- a/src/test/resources/resourceWithEmbargo/FileEmbargo.txt
+++ b/src/test/resources/resourceWithEmbargo/FileEmbargo.txt
@@ -1,3 +1,6 @@
+   concat                |                             text_value                              | start_date
+--------------------------------------+---------------------------------------------------------------------+--------
 https://hdl.handle.net/11250/2683076;Simulated precipitation fields with variance consistent interpolation.pdf;2023-10-01
 https://hdl.handle.net/11250/2683076;Simulated precipitation fields with variance consistent interpolation.pdf.jpg;2023-10-01
 https://hdl.handle.net/11250/2683076;Simulated precipitation fields with variance consistent interpolation.pdf.txt;2023-10-01
+(3 Rows)

--- a/src/test/resources/resourceWithEmbargo/FileEmbargo.txt
+++ b/src/test/resources/resourceWithEmbargo/FileEmbargo.txt
@@ -3,4 +3,4 @@
 https://hdl.handle.net/11250/2683076;Simulated precipitation fields with variance consistent interpolation.pdf;2023-10-01
 https://hdl.handle.net/11250/2683076;Simulated precipitation fields with variance consistent interpolation.pdf.jpg;2023-10-01
 https://hdl.handle.net/11250/2683076;Simulated precipitation fields with variance consistent interpolation.pdf.txt;2023-10-01
-(3 Rows)
+(3 rows)


### PR DESCRIPTION
I dag fjerner Sølvi to første linjer og den siste linja fra embargofila manuelt, for hver enkel fil. I følge Sølvi alle genererte embargo filer har samme struktur, dvs. to første linjer og den siste linja skal fjernes. 