### PR TITLE
NP-45840 Aggregate content files to records with same cristin id

### DIFF
--- a/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/record/content/ResourceContent.java
+++ b/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/record/content/ResourceContent.java
@@ -1,7 +1,9 @@
 package no.sikt.nva.brage.migration.common.model.record.content;
 
+import static java.util.Objects.isNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import nva.commons.core.JacocoGenerated;
@@ -29,6 +31,13 @@ public class ResourceContent {
                    .filter(contentFile -> contentFile.getFilename().equals(filename))
                    .findAny()
                    .orElse(null);
+    }
+
+    public void addContentFile(ContentFile contentFile) {
+        if (isNull(this.contentFiles)) {
+            this.contentFiles = new ArrayList<>();
+        }
+        this.contentFiles.add(contentFile);
     }
 
     @JacocoGenerated

--- a/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/record/content/ResourceContent.java
+++ b/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/record/content/ResourceContent.java
@@ -17,6 +17,10 @@ public class ResourceContent {
         this.contentFiles = contentFiles;
     }
 
+    public ResourceContent(ContentFile contentFile) {
+        this(new ArrayList<>(List.of(contentFile)));
+    }
+
     @JsonProperty("contentFiles")
     public List<ContentFile> getContentFiles() {
         return contentFiles;

--- a/src/main/java/no/sikt/nva/UnisContent.java
+++ b/src/main/java/no/sikt/nva/UnisContent.java
@@ -12,6 +12,7 @@ import static no.sikt.nva.validators.UnisContentValidator.validateRow;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -127,7 +128,7 @@ public final class UnisContent {
             fileIdentifier,
             License.fromBrageLicense(getLicense()),
             getEmbargo());
-        record.setContentBundle(new ResourceContent(List.of(contentFile)));
+        record.setContentBundle(new ResourceContent(new ArrayList<>(List.of(contentFile))));
 
         return record;
     }

--- a/src/main/java/no/sikt/nva/UnisContent.java
+++ b/src/main/java/no/sikt/nva/UnisContent.java
@@ -12,8 +12,6 @@ import static no.sikt.nva.validators.UnisContentValidator.validateRow;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import no.sikt.nva.brage.migration.common.model.record.EntityDescription;
@@ -128,7 +126,7 @@ public final class UnisContent {
             fileIdentifier,
             License.fromBrageLicense(getLicense()),
             getEmbargo());
-        record.setContentBundle(new ResourceContent(new ArrayList<>(List.of(contentFile))));
+        record.setContentBundle(new ResourceContent(contentFile));
 
         return record;
     }

--- a/src/test/java/no/sikt/nva/UnisContentScrapingResultTest.java
+++ b/src/test/java/no/sikt/nva/UnisContentScrapingResultTest.java
@@ -8,8 +8,10 @@ import static no.sikt.nva.validators.ExcelTestingUtils.removeValue;
 import static no.sikt.nva.validators.ExcelTestingUtils.substituteValue;
 import static no.sikt.nva.validators.UnisContentValidator.CRISTIN_ID_COLUMN;
 import static no.sikt.nva.validators.UnisContentValidator.TITLE_COLUMN;
+import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -24,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 class UnisContentScrapingResultTest {
 
+    public static final int RANDOM_CRISTIN_ID = 123;
     private Object[] VALID_HEADERS;
     private Object[] VALID_ROW;
 
@@ -97,5 +100,47 @@ class UnisContentScrapingResultTest {
         assertThrows(ExcelException.class,
                      () -> UnisContentScrapingResult.fromWorkbook(createWorkbook(invalidExcelData)),
                      ERROR_MESSAGE_INVALID_HEADERS);
+    }
+
+    @Test
+    void shouldAppendContentFilesToSameRecordWhenCristinIdIsIdentical()
+        throws ExcelException, InvalidUnisContentException, URISyntaxException {
+
+        var firstCristinId = randomInteger();
+        var firstRowWithDuplicateCristinId = substituteValue(VALID_ROW, firstCristinId, CRISTIN_ID_COLUMN);
+        var secondRowWithDuplicateCristinId = substituteValue(VALID_ROW, firstCristinId, CRISTIN_ID_COLUMN);
+
+        var secondCristinId = randomInteger();
+        var thirdRowWithUniqueCristinId = substituteValue(VALID_ROW, secondCristinId, CRISTIN_ID_COLUMN);
+
+        var validExcelData = new Object[][]{
+            VALID_HEADERS,
+            firstRowWithDuplicateCristinId,
+            secondRowWithDuplicateCristinId,
+            thirdRowWithUniqueCristinId
+        };
+
+        var records = UnisContentScrapingResult.fromWorkbook(createWorkbook(validExcelData)).getResults();
+        assertNotNull(records);
+        assertThat(records.size(), is(equalTo(2)));
+
+        var recordWithMultipleFiles = records.stream()
+                                          .filter(
+                                              record -> Integer.toString(firstCristinId).equals(record.getCristinId()))
+                                          .findAny()
+                                          .orElse(null);
+        assertNotNull(recordWithMultipleFiles);
+        assertNotNull(recordWithMultipleFiles.getContentBundle());
+        assertNotNull(recordWithMultipleFiles.getContentBundle().getContentFiles());
+        assertThat(recordWithMultipleFiles.getContentBundle().getContentFiles().size(), is(equalTo(2)));
+
+        var recordWithOneFile = records.stream()
+                                    .filter(record -> Integer.toString(secondCristinId).equals(record.getCristinId()))
+                                    .findAny()
+                                    .orElse(null);
+        assertNotNull(recordWithOneFile);
+        assertNotNull(recordWithOneFile.getContentBundle());
+        assertNotNull(recordWithOneFile.getContentBundle().getContentFiles());
+        assertThat(recordWithOneFile.getContentBundle().getContentFiles().size(), is(equalTo(1)));
     }
 }

--- a/src/test/java/no/sikt/nva/UnisContentScrapingResultTest.java
+++ b/src/test/java/no/sikt/nva/UnisContentScrapingResultTest.java
@@ -127,8 +127,6 @@ class UnisContentScrapingResultTest {
                                               record -> Integer.toString(firstCristinId).equals(record.getCristinId()))
                                           .findAny()
                                           .orElse(null);
-        assertNotNull(recordWithMultipleFiles);
-        assertNotNull(recordWithMultipleFiles.getContentBundle());
         assertNotNull(recordWithMultipleFiles.getContentBundle().getContentFiles());
         assertThat(recordWithMultipleFiles.getContentBundle().getContentFiles().size(), is(equalTo(2)));
 
@@ -136,8 +134,6 @@ class UnisContentScrapingResultTest {
                                     .filter(record -> Integer.toString(secondCristinId).equals(record.getCristinId()))
                                     .findAny()
                                     .orElse(null);
-        assertNotNull(recordWithOneFile);
-        assertNotNull(recordWithOneFile.getContentBundle());
         assertNotNull(recordWithOneFile.getContentBundle().getContentFiles());
         assertThat(recordWithOneFile.getContentBundle().getContentFiles().size(), is(equalTo(1)));
     }

--- a/src/test/java/no/sikt/nva/UnisContentScrapingResultTest.java
+++ b/src/test/java/no/sikt/nva/UnisContentScrapingResultTest.java
@@ -25,8 +25,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class UnisContentScrapingResultTest {
-
-    public static final int RANDOM_CRISTIN_ID = 123;
     private Object[] VALID_HEADERS;
     private Object[] VALID_ROW;
 


### PR DESCRIPTION
When there are (unit content) rows with duplicate cristin id, the files are aggregated to one record. 
A caveat is that PublishingAuthority can be different from file to file, but the value is set directly on the Record-object. Thus, PublishingAuthority will be set to the value of the first unis content file processed.