### PR TITLE
scraping journal from citation field for uio

### DIFF
--- a/src/main/java/no/sikt/nva/channelregister/ChannelRegister.java
+++ b/src/main/java/no/sikt/nva/channelregister/ChannelRegister.java
@@ -106,7 +106,7 @@ public final class ChannelRegister {
                                                            String customer) {
         if (typeIsPresentInDublinCore(dublinCore) && !isInCristin(dublinCore)) {
             if (isJournalArticle(dublinCore, customer)) {
-                return getErrorDetailsForJournalArticle(dublinCore, brageLocation);
+                return getErrorDetailsForJournalArticle(dublinCore, brageLocation, customer);
             }
             if (hasPublisher(dublinCore) && isSearchableInPublishers(dublinCore, customer)) {
                 return getErrorDetailsForPublisher(dublinCore, brageLocation, customer);
@@ -352,8 +352,8 @@ public final class ChannelRegister {
     }
 
     private Optional<ErrorDetails> getErrorDetailsForJournalArticle(DublinCore dublinCore,
-                                                                    BrageLocation brageLocation) {
-        var publication = DublinCoreScraper.extractPublication(dublinCore);
+                                                                    BrageLocation brageLocation, String customer) {
+        var publication = DublinCoreScraper.extractPublication(dublinCore, customer);
         var possibleIdentifier = lookUpInJournal(publication, brageLocation);
         if (nonNull(possibleIdentifier)) {
             return Optional.empty();
@@ -367,7 +367,7 @@ public final class ChannelRegister {
                                                                BrageLocation brageLocation,
                                                                String customer) {
         var publisher = formatValue(DublinCoreScraper.extractPublisher(dublinCore));
-        var publication = DublinCoreScraper.extractPublication(dublinCore);
+        var publication = DublinCoreScraper.extractPublication(dublinCore, customer);
         var journalIdentifier = lookUpInJournal(publication, brageLocation);
         var publisherIdentifier = lookUpInPublisher(publisher, customer);
         if (nonNull(journalIdentifier)

--- a/src/main/java/no/sikt/nva/scrapers/ResourceOwnerMapper.java
+++ b/src/main/java/no/sikt/nva/scrapers/ResourceOwnerMapper.java
@@ -180,7 +180,7 @@ public class ResourceOwnerMapper {
     public static final String STATPED_CRISTIN_IDENTIFIER = "5831.0.0.0";
     public static final String VEGVESEN_OWNER_VALUE = "vegvesen@6056.0.0.0";
     public static final String VEGVESEN_CRISTIN_IDENTIFIER = "6056.0.0.0";
-    public static final String FFI_OWNER_VALUE = "ffi@6056.0.0.0";
+    public static final String FFI_OWNER_VALUE = "ffi@7428.0.0.0";
     public static final String FFI_CRISTIN_IDENTIFIER = "7428.0.0.0";
     public static final String CRISTIN_IDENTIFIER = "CRISTIN_IDENTIFIER";
     public static final String OWNER_VALUE = "OWNER_VALUE";


### PR DESCRIPTION
`dc.identifier.citation` is a field we are ignoring under import.

UiO has stored journal names in following field for thousands of publications. 
When making search in channel register, we search by issn or journal name. When both of this fields are empty for UiO, we trying to scrape journal name from citation. All Journals have following format:

`BMC Pregnancy and Childbirth. 2015 Dec 01;15(1):321`	

Where everything in front of dot is journal name. 