### PR TITLE
keeping custom license file when scraping contents

### DIFF
--- a/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/record/content/ResourceContent.java
+++ b/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/record/content/ResourceContent.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.brage.migration.common.model.record.content;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
@@ -23,7 +24,11 @@ public class ResourceContent {
 
     @JsonProperty("contentFiles")
     public List<ContentFile> getContentFiles() {
-        return contentFiles;
+        return nonNull(contentFiles) ? contentFiles : List.of();
+    }
+
+    public static ResourceContent emptyResourceContent() {
+        return new ResourceContent(List.of());
     }
 
     public void setContentFiles(List<ContentFile> contentFiles) {

--- a/src/test/java/no/sikt/nva/scrapers/ContentScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/ContentScraperTest.java
@@ -7,6 +7,8 @@ import static no.sikt.nva.scrapers.ContentScraper.UNKNOWN_FILE_LOG_MESSAGE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Path;
 import java.time.LocalDate;
@@ -15,6 +17,7 @@ import java.util.stream.Collectors;
 import no.sikt.nva.brage.migration.common.model.BrageLocation;
 import no.sikt.nva.brage.migration.common.model.record.WarningDetails.Warning;
 import no.sikt.nva.brage.migration.common.model.record.content.ContentFile;
+import no.sikt.nva.brage.migration.common.model.record.content.ResourceContent.BundleType;
 import no.sikt.nva.brage.migration.common.model.record.license.License;
 import no.sikt.nva.exceptions.ContentException;
 import nva.commons.logutils.LogUtils;
@@ -24,6 +27,7 @@ public class ContentScraperTest {
 
     public static final String ORIGINAL_FILENAME_1 = "rapport2022_25_1.pdf";
     public static final String ORIGINAL_FILENAME_2 = "rapport2022_25_2.pdf";
+    public static final String CUSTOM_LICENSE_PDF_FILENAME = "CustomLicense.pdf";
     private static final License someLicense = new License(null, null);
     private ContentScraper contentScraper = new ContentScraper(Path.of(CONTENT_FILE_PATH),
                                                                new BrageLocation(null),
@@ -36,7 +40,16 @@ public class ContentScraperTest {
                                             .stream()
                                             .map(ContentFile::getFilename)
                                             .collect(Collectors.toList());
-        assertThat(actualContentFilenameList, containsInAnyOrder(ORIGINAL_FILENAME_1, ORIGINAL_FILENAME_2));
+        assertThat(actualContentFilenameList, containsInAnyOrder(ORIGINAL_FILENAME_1, ORIGINAL_FILENAME_2, CUSTOM_LICENSE_PDF_FILENAME));
+    }
+
+    @Test
+    void shouldScrapeNonDefaultLicenseFile() throws ContentException {
+        var resourceContent = contentScraper.scrapeContent();
+        var licenseFile = resourceContent.getContentFiles().stream()
+                              .filter(file -> file.getBundleType().equals(BundleType.LICENSE))
+                              .findFirst().orElseThrow();
+        assertThat(licenseFile.getFilename(), is(equalTo(CUSTOM_LICENSE_PDF_FILENAME)));
     }
 
     @Test
@@ -49,7 +62,7 @@ public class ContentScraperTest {
 
         assertTrue(actualContentFilenameList.stream().allMatch(contentFile -> contentFile.getEmbargoDate().equals(expectedEmbargo)));
         assertThat(actualContentFilenameList.stream().map(ContentFile::getFilename).collect(Collectors.toList()),
-                   containsInAnyOrder(ORIGINAL_FILENAME_1, ORIGINAL_FILENAME_2));
+                   containsInAnyOrder(ORIGINAL_FILENAME_1, ORIGINAL_FILENAME_2, CUSTOM_LICENSE_PDF_FILENAME));
     }
 
     @Test

--- a/src/test/resources/contents
+++ b/src/test/resources/contents
@@ -4,6 +4,7 @@ rapport2022_25_2.pdf	bundle:ORIGINAL	description:Datagrunnlag_2
 cristin-1825416.xml	bundle:METADATA
 license_rdf	bundle:CC-LICENSE
 license.txt	bundle:LICENSE
+CustomLicense.pdf	bundle:LICENSE
 ORE.xml	bundle:ORE
 rapport2022_25.pdf.txt	bundle:TEXT	description:Extracted text
 rapport2022_25.pdf.jpg	bundle:THUMBNAIL	description:Generated Thumbnail


### PR DESCRIPTION
Many Brage posts contain custom licenses which are visible only for administrators and owners. This licenses should be migrated to NVA as administrative agreements. 

See example in the task:

https://unit.atlassian.net/jira/software/c/projects/NP/boards/111?assignee=62a07ba3954f50006fcc2c2a&selectedIssue=NP-46842