### PR TITLE
ignoring vegvesen when making fetch file api call

### DIFF
--- a/src/main/java/no/sikt/nva/scrapers/embargo/CustomerAddressResolver.java
+++ b/src/main/java/no/sikt/nva/scrapers/embargo/CustomerAddressResolver.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 
 public class CustomerAddressResolver {
 
-    public static final Set<String> IGNORED_CUSTOMERS = Set.of("ffi");
+    public static final Set<String> IGNORED_CUSTOMERS = Set.of("ffi", "vegvesen");
     private static final Logger logger = LoggerFactory.getLogger(CustomerAddressResolver.class);
     private static final char SEPARATOR = ';';
     private static final String CUSTOMER_ADDRESSES = "customer_address.csv";


### PR DESCRIPTION
Poster som ble slettet blir låst i nva. Vi må evt. finne ut av hva vi gjør, men dette muliggjør å kjøre vegvesenet. (Vegvesen mangler også i `customer_address.csv`