### PR TITLE
extending doi validator

### DIFF
--- a/src/main/java/no/sikt/nva/validators/DoiValidator.java
+++ b/src/main/java/no/sikt/nva/validators/DoiValidator.java
@@ -97,7 +97,7 @@ public class DoiValidator {
             return handleDoiWithColon(doi);
         }
         if (doi.toLowerCase(Locale.ROOT).contains(HTTP_STRING.toLowerCase(Locale.ROOT)) || doi.contains(DOI_DOMAIN_NAME)) {
-            return HTTPS_STRING + DOI_DOMAIN_NAME + inputDoi.split(DOI_DOMAIN_NAME)[1];
+            return HTTPS_STRING + DOI_DOMAIN_NAME + doi.split(DOI_DOMAIN_NAME)[1];
         }
         return HTTPS_STRING + DOI_DOMAIN_NAME + doi;
     }
@@ -211,7 +211,7 @@ public class DoiValidator {
     }
 
     public static boolean isValidDoi(String doi) {
-        var doiRegex = "^(https?://)?(doi\\.org/)?10.\\d{4,9}/[^\\s#%]+/?$";
+        var doiRegex = "^(https?://)?(doi\\.org/)?10.\\d{4,9}/\\S+/?$";
         var pattern = Pattern.compile(doiRegex, Pattern.CASE_INSENSITIVE);
         return pattern.matcher(doi).matches();
     }

--- a/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
@@ -113,7 +113,8 @@ public class DublinCoreScraperTest {
             Arguments.of("doi:10.5194/tc-8-1885-2014", "https://doi.org/10.5194/tc-8-1885-2014"),
             Arguments.of("DOI:10.1371/journal.pone.0125743", "https://doi.org/10.1371/journal.pone.0125743"),
             Arguments.of("https://doi.org/10.1177%2F1757975910383936", "https://doi.org/10.1177/1757975910383936"),
-            Arguments.of("https://doi.org/10.1155/2021/6684334", "https://doi.org/10.1155/2021/6684334")
+            Arguments.of("https://doi.org/10.1155/2021/6684334", "https://doi.org/10.1155/2021/6684334"),
+            Arguments.of("https://doi.org/10.1016/j.isci. 2020.101414", "https://doi.org/10.1016/j.isci.2020.101414")
         );
     }
 
@@ -603,7 +604,7 @@ public class DublinCoreScraperTest {
     @Test
     void shouldLoggInvalidDoi() {
         var dcType = toDcType("Book");
-        var dcDoi = new DcValue(Element.IDENTIFIER, Qualifier.DOI, "10.1016/ S0140-6736wefwfg.(20)30045-#%wt3");
+        var dcDoi = new DcValue(Element.IDENTIFIER, Qualifier.DOI, "0.1016/S0140-6736wefwfg.(20)30045-#%wt3");
         var dublinCoreWithDoi = DublinCoreFactory.createDublinCoreWithDcValues(List.of(dcType, dcDoi));
         var appender = LogUtils.getTestingAppenderForRootLogger();
         dcScraper.validateAndParseDublinCore(

--- a/src/test/java/no/sikt/nva/validators/DoiValidatorTest.java
+++ b/src/test/java/no/sikt/nva/validators/DoiValidatorTest.java
@@ -30,7 +30,10 @@ public class DoiValidatorTest {
             Arguments.of("https://doi.org/10.2983/0730-8000(2008)27[525:EOAMRF]2.0.CO;2"),
             Arguments.of("https:/doi.org/10.1080/08039410.2015.1114517"),
             Arguments.of("http://dx.doi.org/10.5334/ah.be"),
-             Arguments.of("https://doi.org/10.1155/2021/6684334")
+            Arguments.of("https://doi.org/10.1155/2021/6684334"),
+            Arguments.of("https://doi.org/10.1016/j.isci. 2020.101414"),
+            Arguments.of("https://doi.org/10.1007/978-3-031-05276-7_12#DOI"),
+            Arguments.of("https://doi.org/10.1007/JHEP05%282024%29260")
         );
     }
 


### PR DESCRIPTION
Extending doi validator to accept doi with characters as # and % in last path.