### PR TITLE
do not keep subject in descriptions when present

### DIFF
--- a/src/main/java/no/sikt/nva/BrageProcessor.java
+++ b/src/main/java/no/sikt/nva/BrageProcessor.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -240,9 +241,19 @@ public class BrageProcessor implements Runnable {
                    .map(r -> EmbargoParser.checkForEmbargoFromSuppliedEmbargoFile(r, embargoes, onlineEmbargoChecker));
     }
 
-    private Record injectValuesFromFsDublinCore(Record record, DublinCore dublinCore) {
-        record.setSubjectCode(DublinCoreScraper.extractSubjectCode(dublinCore));
+    public static Record injectValuesFromFsDublinCore(Record record, DublinCore dublinCore) {
+        var subjectCode = DublinCoreScraper.extractSubjectCode(dublinCore);
+        record.setSubjectCode(subjectCode);
+        updateDescriptionsIfNeeded(record, subjectCode);
         return record;
+    }
+
+    private static void updateDescriptionsIfNeeded(Record record, String subjectCode) {
+        if (nonNull(subjectCode)) {
+            var descriptions = new ArrayList<>(record.getEntityDescription().getDescriptions());
+            descriptions.remove(subjectCode);
+            record.getEntityDescription().setDescriptions(descriptions);
+        }
     }
 
     private Record injectBrageLocation(Record record, BrageLocation brageLocation) {

--- a/src/test/java/no/sikt/nva/BrageProcessorTest.java
+++ b/src/test/java/no/sikt/nva/BrageProcessorTest.java
@@ -1,0 +1,42 @@
+package no.sikt.nva;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import no.sikt.nva.brage.migration.common.model.record.EntityDescription;
+import no.sikt.nva.brage.migration.common.model.record.Record;
+import no.sikt.nva.model.dublincore.DcValue;
+import no.sikt.nva.model.dublincore.DublinCore;
+import no.sikt.nva.model.dublincore.Element;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+class BrageProcessorTest {
+
+    @Test
+    void shouldRemoveSubjectCodeFromDescriptionsIfPresentInBothDescriptionsAndSubjectCode() {
+        var subjectCode = randomString();
+        var record = recordWithSubjectCodeInDescriptions(subjectCode);
+
+        assertTrue(record.getEntityDescription().getDescriptions().contains(subjectCode));
+
+        var updatedRecord = BrageProcessor.injectValuesFromFsDublinCore(record, dublinCoreWithSubjectCode(subjectCode));
+
+        assertFalse(updatedRecord.getEntityDescription().getDescriptions().contains(subjectCode));
+        assertEquals(updatedRecord.getSubjectCode(), subjectCode);
+    }
+
+    private static @NotNull DublinCore dublinCoreWithSubjectCode(String subjectCode) {
+        return new DublinCore(List.of(new DcValue(Element.SUBJECT_CODE, null, subjectCode)));
+    }
+
+    private static Record recordWithSubjectCodeInDescriptions(String subjectCode) {
+        var record = new Record();
+        var entityDescription = new EntityDescription();
+        entityDescription.setDescriptions(List.of(subjectCode));
+        record.setEntityDescription(entityDescription);
+        return record;
+    }
+}

--- a/src/test/java/no/sikt/nva/scrapers/EntityDescriptionExtractorTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/EntityDescriptionExtractorTest.java
@@ -1,20 +1,18 @@
 package no.sikt.nva.scrapers;
 
-import java.io.File;
-import no.sikt.nva.brage.migration.common.model.BrageLocation;
-import no.sikt.nva.model.dublincore.DcValue;
-import no.sikt.nva.model.dublincore.Element;
-import no.sikt.nva.model.dublincore.Qualifier;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.Map;
-
 import static no.sikt.nva.ResourceNameConstants.TEST_RESOURCE_PATH;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import no.sikt.nva.brage.migration.common.model.BrageLocation;
+import no.sikt.nva.model.dublincore.DcValue;
+import no.sikt.nva.model.dublincore.Element;
+import no.sikt.nva.model.dublincore.Qualifier;
+import org.junit.jupiter.api.Test;
 
 public class EntityDescriptionExtractorTest {
 


### PR DESCRIPTION
Following publication has subject code in both descriptions and course field. This is because subject code is present as description in dublin_core.xml and subjectCode in metadata_fs.xml. 

When present as subject and in descriptions -> removing from descriptions.