### PR TITLE
removed logging for invalid languager, keeping warning

### DIFF
--- a/src/main/java/no/sikt/nva/scrapers/BrageNvaLanguageMapper.java
+++ b/src/main/java/no/sikt/nva/scrapers/BrageNvaLanguageMapper.java
@@ -1,24 +1,18 @@
 package no.sikt.nva.scrapers;
 
 import static nva.commons.core.language.LanguageMapper.LEXVO_URI_UNDEFINED;
-import java.net.URI;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import no.sikt.nva.brage.migration.common.model.ErrorDetails;
-import no.sikt.nva.brage.migration.common.model.ErrorDetails.Error;
 import no.sikt.nva.brage.migration.common.model.record.Language;
 import no.sikt.nva.brage.migration.common.model.record.WarningDetails;
 import no.sikt.nva.brage.migration.common.model.record.WarningDetails.Warning;
 import no.sikt.nva.model.dublincore.DcValue;
 import no.sikt.nva.model.dublincore.DublinCore;
-import nva.commons.core.StringUtils;
 import nva.commons.core.language.LanguageMapper;
 
 public class BrageNvaLanguageMapper {
 
-    public static final int ONE_ELEMENT = 1;
 
     public static Language extractLanguage(DublinCore dublinCore) {
         var languagesDcValues = getLanguagesAsDcValues(dublinCore);
@@ -41,41 +35,6 @@ public class BrageNvaLanguageMapper {
                 invalidLanguages.stream().map(DcValue::getValue).collect(Collectors.toSet());
             return Optional.of(new WarningDetails(Warning.LANGUAGE_MAPPED_TO_UNDEFINED, invalidLanguagesValues));
         }
-    }
-
-    public static Optional<ErrorDetails> getLanguageError(DublinCore dublinCore) {
-        var languages = dublinCore.getDcValues().stream()
-                            .filter(DcValue::isLanguage)
-                            .map(DcValue::getValue)
-                            .collect(Collectors.toSet());
-        if (languages.size() > ONE_ELEMENT) {
-            return getMultipleLanguageError(languages);
-        }
-        if (languages.size() == ONE_ELEMENT) {
-            var mappedToNvaLanguage = LanguageMapper.toUri(languages.iterator().next());
-            if (LEXVO_URI_UNDEFINED.equals(mappedToNvaLanguage) && StringUtils.isNotEmpty(
-                languages.iterator().next())) {
-                return Optional.of(new ErrorDetails(Error.INVALID_DC_LANGUAGE, languages));
-            }
-        }
-        return Optional.empty();
-    }
-
-    private static Optional<ErrorDetails> getMultipleLanguageError(Set<String> languages) {
-        return getIsoLanguages(languages).isEmpty()
-                   ? Optional.of(new ErrorDetails(Error.MULTIPLE_DC_LANGUAGES_PRESENT, languages))
-                   : Optional.empty();
-    }
-
-    private static Set<URI> getIsoLanguages(Set<String> languages) {
-        var isoLanguages = new HashSet<URI>();
-        for (String language : languages) {
-            var isoLanguageUri = LanguageMapper.toUri(language);
-            if (!isoLanguageUri.equals(LEXVO_URI_UNDEFINED)) {
-                isoLanguages.add(isoLanguageUri);
-            }
-        }
-        return isoLanguages;
     }
 
     private static Set<String> getLanguageValues(Set<DcValue> languagesDcValues) {

--- a/src/main/java/no/sikt/nva/validators/DublinCoreValidator.java
+++ b/src/main/java/no/sikt/nva/validators/DublinCoreValidator.java
@@ -67,7 +67,6 @@ public final class DublinCoreValidator {
         getIssnErrors(dublinCore).ifPresent(errors::add);
         getDateError(dublinCore).ifPresent(errors::add);
         getIsmnError(dublinCore).ifPresent(errors::add);
-        BrageNvaLanguageMapper.getLanguageError(dublinCore).ifPresent(errors::add);
         getMultipleUnmappableTypeError(dublinCore, customer).ifPresent(errors::add);
         getMultipleValues(dublinCore).ifPresent(errors::addAll);
         getLicenseError(dublinCore).ifPresent(errors::add);

--- a/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
@@ -4,7 +4,6 @@ import static no.sikt.nva.ResourceNameConstants.TEST_RESOURCE_PATH;
 import static no.sikt.nva.brage.migration.common.model.ErrorDetails.Error.DC_PUBLISHER_NOT_IN_CHANNEL_REGISTER;
 import static no.sikt.nva.brage.migration.common.model.ErrorDetails.Error.DUPLICATE_JOURNAL_IN_CHANNEL_REGISTER;
 import static no.sikt.nva.brage.migration.common.model.ErrorDetails.Error.INVALID_DC_IDENTIFIER_DOI_OFFLINE_CHECK;
-import static no.sikt.nva.brage.migration.common.model.ErrorDetails.Error.INVALID_DC_LANGUAGE;
 import static no.sikt.nva.brage.migration.common.model.ErrorDetails.Error.INVALID_DC_RIGHTS_URI;
 import static no.sikt.nva.brage.migration.common.model.ErrorDetails.Error.INVALID_DC_TYPE;
 import static no.sikt.nva.brage.migration.common.model.ErrorDetails.Error.INVALID_ISSN;
@@ -15,12 +14,13 @@ import static no.sikt.nva.brage.migration.common.model.ErrorDetails.Error.MULTIP
 import static no.sikt.nva.brage.migration.common.model.record.PrioritizedProperties.ABSTRACT;
 import static no.sikt.nva.brage.migration.common.model.record.PrioritizedProperties.ALTERNATIVE_ABSTRACTS;
 import static no.sikt.nva.brage.migration.common.model.record.PrioritizedProperties.ALTERNATIVE_TITLES;
+import static no.sikt.nva.brage.migration.common.model.record.PrioritizedProperties.CONTRIBUTORS_WITH_CREATOR_ROLE;
 import static no.sikt.nva.brage.migration.common.model.record.PrioritizedProperties.FUNDINGS;
 import static no.sikt.nva.brage.migration.common.model.record.PrioritizedProperties.MAIN_TITLE;
-import static no.sikt.nva.brage.migration.common.model.record.PrioritizedProperties.CONTRIBUTORS_WITH_CREATOR_ROLE;
 import static no.sikt.nva.brage.migration.common.model.record.PrioritizedProperties.PUBLISHER;
 import static no.sikt.nva.brage.migration.common.model.record.PrioritizedProperties.REFERENCE;
 import static no.sikt.nva.brage.migration.common.model.record.PrioritizedProperties.TAGS;
+import static no.sikt.nva.brage.migration.common.model.record.WarningDetails.Warning.LANGUAGE_MAPPED_TO_UNDEFINED;
 import static no.sikt.nva.brage.migration.common.model.record.WarningDetails.Warning.PAGE_NUMBER_FORMAT_NOT_RECOGNIZED;
 import static no.sikt.nva.brage.migration.common.model.record.WarningDetails.Warning.SUBJECT_WARNING;
 import static no.sikt.nva.channelregister.ChannelRegister.NOT_FOUND_IN_CHANNEL_REGISTER;
@@ -31,6 +31,7 @@ import static no.sikt.nva.scrapers.LicenseScraper.DEFAULT_LICENSE;
 import static no.unit.nva.testutils.RandomDataGenerator.randomIssn;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static nva.commons.core.language.LanguageMapper.LEXVO_URI_UNDEFINED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
@@ -66,6 +67,7 @@ import no.sikt.nva.brage.migration.common.model.record.Pages;
 import no.sikt.nva.brage.migration.common.model.record.PartOfSeries;
 import no.sikt.nva.brage.migration.common.model.record.PublisherVersion;
 import no.sikt.nva.brage.migration.common.model.record.Range;
+import no.sikt.nva.brage.migration.common.model.record.WarningDetails;
 import no.sikt.nva.brage.migration.common.model.record.WarningDetails.Warning;
 import no.sikt.nva.model.dublincore.DcValue;
 import no.sikt.nva.model.dublincore.Element;
@@ -490,7 +492,7 @@ public class DublinCoreScraperTest {
     }
 
     @Test
-    void nonIsoLanguageShouldBeLoggedAsError() {
+    void nonIsoLanguageShouldLoggedAsWarning() {
         var nonIsoLanguage = randomString();
         var typeDcValue = toDcType("Journal Article");
         var peerReviewed = toDcType("Peer reviewed");
@@ -498,7 +500,7 @@ public class DublinCoreScraperTest {
         var dublinCore = DublinCoreFactory.createDublinCoreWithDcValues(
             List.of(nonIsoLanguageDcValue, typeDcValue, peerReviewed));
         var record = dcScraper.validateAndParseDublinCore(dublinCore, new BrageLocation(null), SOME_CUSTOMER);
-        assertThat(record.getErrors(), hasItem(new ErrorDetails(INVALID_DC_LANGUAGE, Set.of(nonIsoLanguage))));
+        assertThat(record.getWarnings(), hasItem(new WarningDetails(LANGUAGE_MAPPED_TO_UNDEFINED, Set.of(nonIsoLanguage))));
     }
 
     @Test
@@ -1319,6 +1321,19 @@ public class DublinCoreScraperTest {
         assertThat(actualPrioritizedProperties, hasItem(FUNDINGS.getValue()));
         assertThat(actualPrioritizedProperties, hasItem(REFERENCE.getValue()));
         assertThat(actualPrioritizedProperties, hasItem(TAGS.getValue()));
+    }
+
+    @Test
+    void shouldCreateRecordWithUndefinedLanguageWhenLanguageIsUndefined() {
+        var dcValues = List.of(
+            new DcValue(Element.TYPE, null, BrageType.MASTER_THESIS.getValue()),
+            new DcValue(Element.LANGUAGE, null, randomString()));
+        var dublinCore = DublinCoreFactory.createDublinCoreWithDcValues(dcValues);
+        var customerIssuingDegrees = "ntnu";
+        var record = dcScraper.validateAndParseDublinCore(dublinCore, new BrageLocation(null), customerIssuingDegrees);
+
+        assertThat(record.getEntityDescription().getLanguage().getNva(),
+                   is(equalTo(LEXVO_URI_UNDEFINED)));
     }
 
     private static DcValue toDcType(String t) {


### PR DESCRIPTION
We are both logging error and warning for invalid language/ non iso language, but steel creating undefined language. 
Removing error message, keeping only warning. 