### PR TITLE
mapping three report types as research report for ffi

### DIFF
--- a/src/main/java/no/sikt/nva/scrapers/DublinCoreScraper.java
+++ b/src/main/java/no/sikt/nva/scrapers/DublinCoreScraper.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import no.sikt.nva.brage.migration.common.model.BrageLocation;
-import no.sikt.nva.brage.migration.common.model.BrageType;
 import no.sikt.nva.brage.migration.common.model.ErrorDetails;
 import no.sikt.nva.brage.migration.common.model.NvaType;
 import no.sikt.nva.brage.migration.common.model.record.Contributor;

--- a/src/main/java/no/sikt/nva/validators/DublinCoreValidator.java
+++ b/src/main/java/no/sikt/nva/validators/DublinCoreValidator.java
@@ -422,7 +422,7 @@ public final class DublinCoreValidator {
         if (TypeMapper.hasValidType(uniqueTypes.iterator().next())) {
             return Optional.empty();
         }
-        if (nonNull(mapOriginTypeToNvaType(uniqueTypes, dublinCore).getNva())) {
+        if (nonNull(mapOriginTypeToNvaType(uniqueTypes, dublinCore, customer).getNva())) {
             return Optional.empty();
         }
         if (nonNull(mapToNvaTypeIfMappable(uniqueTypes))) {
@@ -438,7 +438,7 @@ public final class DublinCoreValidator {
                         .stream()
                         .distinct()
                         .collect(Collectors.toSet());
-        var mappedType = mapOriginTypeToNvaType(types, dublinCore);
+        var mappedType = mapOriginTypeToNvaType(types, dublinCore, customer);
         if (nonNull(mappedType.getNva())) {
             return Optional.empty();
         }

--- a/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
@@ -47,6 +47,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
@@ -66,6 +67,8 @@ import no.sikt.nva.brage.migration.common.model.record.Pages;
 import no.sikt.nva.brage.migration.common.model.record.PartOfSeries;
 import no.sikt.nva.brage.migration.common.model.record.PublisherVersion;
 import no.sikt.nva.brage.migration.common.model.record.Range;
+import no.sikt.nva.brage.migration.common.model.record.Record;
+import no.sikt.nva.brage.migration.common.model.record.Type;
 import no.sikt.nva.brage.migration.common.model.record.WarningDetails.Warning;
 import no.sikt.nva.model.dublincore.DcValue;
 import no.sikt.nva.model.dublincore.Element;
@@ -75,6 +78,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -1319,6 +1324,16 @@ public class DublinCoreScraperTest {
         assertThat(actualPrioritizedProperties, hasItem(FUNDINGS.getValue()));
         assertThat(actualPrioritizedProperties, hasItem(REFERENCE.getValue()));
         assertThat(actualPrioritizedProperties, hasItem(TAGS.getValue()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BrageType.class, mode = Mode.INCLUDE, names =  {"REPORT", "RESEARCH_REPORT", "OTHER_TYPE_OF_REPORT"})
+    void shouldMapProvidedReportTypesFromBrageAsResearchReportWhenCustomerIsFFI(BrageType brageType) {
+        var dcValues = List.of(new DcValue(Element.TYPE, null, brageType.getValue()));
+        var dublinCore = DublinCoreFactory.createDublinCoreWithDcValues(dcValues);
+        var record = dcScraper.validateAndParseDublinCore(dublinCore, new BrageLocation(null), "ffi");
+
+        assertThat(record.getType().getNva(), equalTo(NvaType.RESEARCH_REPORT.getValue()));
     }
 
     private static DcValue toDcType(String t) {


### PR DESCRIPTION
RT-sak fra FFI:

Jeg har et spørsmål når det gjelder kategoriene i NVA. I dag ligger våre rapporter merket med dokumenttype Rapport, denne skal så vidt jeg ser i NVA være en overordnet gruppe og så skal selve dokumenttypen være ulike typer rapporter. Den mest passende kategorien for oss er Forskningsrapport. Er det mulig at ved overføringen så blir alle endret til Forskningsrapport maskinelt hos dere? Eller må vi gå inn på hver enkelt post i forkant og endre dette selv? Det vil være en ganske stor jobb for det er snakk om nesten 2000 poster.

Mapper REPORT, RESEARCH_REPORT and OTHER_TYPE_OF_REPORT as ResearchReport.