### PR TITLE
NP-47246-multiple-embargo-end-date-in-dublin-core

### DIFF
--- a/post-to-aws/src/test/java/S3StorageValidatorTest.java
+++ b/post-to-aws/src/test/java/S3StorageValidatorTest.java
@@ -25,12 +25,12 @@ public class S3StorageValidatorTest {
     @Test
     void shouldThrowExceptionWhenBucketContainsObjectsFromSameCustomer() throws IOException {
         putObjectInS3();
-        assertThrows(StorageValidatorException.class, ()-> s3StorageValidator.validateStorage());
+        assertThrows(StorageValidatorException.class, () -> s3StorageValidator.validateStorage());
     }
 
     @Test
-    void shouldDoNothingWhenBucketDoesNotContainObjectsFromSameCustomer() throws IOException {
-        assertDoesNotThrow(()-> s3StorageValidator.validateStorage());
+    void shouldDoNothingWhenBucketDoesNotContainObjectsFromSameCustomer() {
+        assertDoesNotThrow(() -> s3StorageValidator.validateStorage());
     }
 
     private void putObjectInS3() throws IOException {

--- a/src/main/java/no/sikt/nva/model/Embargo.java
+++ b/src/main/java/no/sikt/nva/model/Embargo.java
@@ -73,13 +73,17 @@ public class Embargo {
     }
 
     public Instant getDateAsInstant() {
+        return getDateAsInstant(date);
+    }
+
+    public static Instant getDateAsInstant(String date) {
         try {
             var dateTime = ZonedDateTime.of(LocalDate.parse(date),
                                             START_OF_DAY,
                                             EUROPE_OSLO);
             return formatEmbargoDate(dateTime);
         } catch (Exception e) {
-            return parseUnusualDateFormats();
+            return parseUnusualDateFormats(date);
         }
     }
 
@@ -100,11 +104,11 @@ public class Embargo {
     }
 
     @SuppressWarnings("PMD.EmptyCatchBlock")
-    private Instant parseUnusualDateFormats() {
+    private static Instant parseUnusualDateFormats(String date) {
         var weirdFromats = List.of("yyyyy-MM-dd", "yyyyyy-MM-dd", "yyyyyyy-MM-dd", "yyyyyyyy-MM-dd");
         for (var dateFormat : weirdFromats) {
             try {
-                return perseDateOnSpecifiedFormatToInstant(dateFormat);
+                return perseDateOnSpecifiedFormatToInstant(dateFormat, date);
             } catch (Exception e) {
                 //ignored
             }
@@ -112,7 +116,7 @@ public class Embargo {
         throw new RuntimeException("Unable to parse unusual format date:" + date);
     }
 
-    private Instant perseDateOnSpecifiedFormatToInstant(String format) {
+    private static Instant perseDateOnSpecifiedFormatToInstant(String format, String date) {
         var dateTimeFormatter = DateTimeFormatter.ofPattern(format);
         var dateTime = ZonedDateTime.of(LocalDate.parse(date, dateTimeFormatter),
                                         START_OF_DAY,

--- a/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
@@ -1181,6 +1181,21 @@ public class DublinCoreScraperTest {
     }
 
     @Test
+    void shouldPickMostRecentEmbargoDate(){
+        var invalidEmbargoDate = "";
+        var embargoDate = "2024-08-26";
+        var embargoDateMostRecent = "2025-08-26";
+        var dcValueInvalidEmbargoDate = new DcValue(Element.DATE, Qualifier.EMBARGO_DATE, invalidEmbargoDate);
+        var dcValueEmbargoDate = new DcValue(Element.DATE, Qualifier.EMBARGO_DATE, embargoDate);
+        var dvValueEmbargoMostRecent = new DcValue(Element.DATE, Qualifier.EMBARGO_DATE, embargoDateMostRecent);
+        var dublinCore = DublinCoreFactory.createDublinCoreWithDcValues(List.of(dcValueInvalidEmbargoDate,
+                                                                                dcValueEmbargoDate,
+                                                                                dvValueEmbargoMostRecent));
+        var embargo = DublinCoreScraper.extractEmbargo(dublinCore);
+        assertThat(embargo, is(equalTo(embargoDateMostRecent)));
+    }
+
+    @Test
     void shouldReturnInvalidLicenseErrorWhenFailingToExtractLicense() {
         var licenseValue = "http://creativecommons.org/licenses/by/4.0\"";
         var invalidLicense = new DcValue(Element.RIGHTS, Qualifier.URI, licenseValue);

--- a/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
@@ -46,7 +46,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.net.URI;
@@ -89,7 +88,7 @@ public class DublinCoreScraperTest {
     private static final String SOME_CUSTOMER = "nve";
     public static final String METADATA_FS_XML = "metadata_fs.xml";
 
-    private static boolean SHOULD_VALIDATE_ONLINE = false;
+    private static final boolean SHOULD_VALIDATE_ONLINE = false;
     private DublinCoreScraper dcScraper;
 
     public static Stream<Arguments> isPartOfSeriesProvider() {
@@ -1077,17 +1076,6 @@ public class DublinCoreScraperTest {
         var record = dcScraper.validateAndParseDublinCore(dublinCore, new BrageLocation(null), "ntnu");
         assertThat(record.getType().getNva(), is(equalTo(NvaType.RECORDING_MUSICAL.getValue())));
 
-    }
-
-    @Test
-    void shouldExtractFirstEmbargoIfDublinCoreContainsMultipleEmbargoes() {
-        var dcType = toDcType("Musical score");
-        var firstEmbargo = new DcValue(Element.DATE, Qualifier.EMBARGO_DATE, "someDate");
-        var secondEmbargo = new DcValue(Element.DATE, Qualifier.EMBARGO_DATE, "someDate");
-        var dublinCore = DublinCoreFactory.createDublinCoreWithDcValues(
-            List.of(dcType, firstEmbargo, secondEmbargo));
-
-        assertDoesNotThrow(() -> DublinCoreScraper.extractEmbargo(dublinCore));
     }
 
     @Test


### PR DESCRIPTION
This is a bugfix for handling multiple embargo date in the same Dublin_Core such as this example: https://openaccess.nhh.no/nhh-xmlui/handle/11250/2565494?show=full

Den skal nå ta datoen som er størst.