### PR TITLE
scraping inspera and wiseflow identifiers

### DIFF
--- a/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/record/Record.java
+++ b/brage-migration-common/src/main/java/no/sikt/nva/brage/migration/common/model/record/Record.java
@@ -42,6 +42,8 @@ public class Record {
     private ResourceContent contentBundle;
     private PublishedDate publishedDate;
     private String cristinId;
+    private String insperaIdentifier;
+    private String wiseflowIdentifier;
     private String brageLocation;
     private Set<ErrorDetails> errors;
     private Set<WarningDetails> warnings;
@@ -61,44 +63,45 @@ public class Record {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof Record)) {
             return false;
         }
         Record record = (Record) o;
-        return Objects.equals(getEntityDescription(), record.getEntityDescription())
-               && Objects.equals(getCustomer(), record.getCustomer())
-               && Objects.equals(getId(), record.getId())
-               && Objects.equals(getDoi(), record.getDoi())
-               && Objects.equals(getType(), record.getType())
-               && Objects.equals(getPublisherAuthority(), record.getPublisherAuthority())
-               && Objects.equals(getRightsholder(), record.getRightsholder())
-               && Objects.equals(getSpatialCoverage(), record.getSpatialCoverage())
-               && Objects.equals(getPartOf(), record.getPartOf())
-               && Objects.equals(getPart(), record.getPart())
-               && Objects.equals(getPublication(), record.getPublication())
-               && Objects.equals(getContentBundle(), record.getContentBundle())
-               && Objects.equals(getPublishedDate(), record.getPublishedDate())
-               && Objects.equals(getCristinId(), record.getCristinId())
-               && Objects.equals(getBrageLocation(), record.getBrageLocation())
-               && Objects.equals(getErrors(), record.getErrors())
-               && Objects.equals(getWarnings(), record.getWarnings())
-               && Objects.equals(getLink(), record.getLink())
-               && Objects.equals(getSubjects(), record.getSubjects())
-               && Objects.equals(getSubjectCode(), record.getSubjectCode())
-               && Objects.equals(getAccessCode(), record.getAccessCode())
-               && Objects.equals(getPrioritizedProperties(), record.getPrioritizedProperties())
-               && Objects.equals(getProjects(), record.getProjects());
+        return Objects.equals(getEntityDescription(), record.getEntityDescription()) &&
+               Objects.equals(getCustomer(), record.getCustomer()) &&
+               Objects.equals(getId(), record.getId()) && Objects.equals(getDoi(), record.getDoi()) &&
+               Objects.equals(getType(), record.getType()) &&
+               Objects.equals(getPublisherAuthority(), record.getPublisherAuthority()) &&
+               Objects.equals(getRightsholder(), record.getRightsholder()) &&
+               Objects.equals(getSpatialCoverage(), record.getSpatialCoverage()) &&
+               Objects.equals(getPartOf(), record.getPartOf()) &&
+               Objects.equals(getPart(), record.getPart()) &&
+               Objects.equals(getPublication(), record.getPublication()) &&
+               Objects.equals(getContentBundle(), record.getContentBundle()) &&
+               Objects.equals(getPublishedDate(), record.getPublishedDate()) &&
+               Objects.equals(getCristinId(), record.getCristinId()) &&
+               Objects.equals(getInsperaIdentifier(), record.getInsperaIdentifier()) &&
+               Objects.equals(getWiseflowIdentifier(), record.getWiseflowIdentifier()) &&
+               Objects.equals(getBrageLocation(), record.getBrageLocation()) &&
+               Objects.equals(getErrors(), record.getErrors()) &&
+               Objects.equals(getWarnings(), record.getWarnings()) &&
+               Objects.equals(getLink(), record.getLink()) &&
+               Objects.equals(getSubjects(), record.getSubjects()) &&
+               Objects.equals(getSubjectCode(), record.getSubjectCode()) &&
+               Objects.equals(getAccessCode(), record.getAccessCode()) &&
+               Objects.equals(getProjects(), record.getProjects()) &&
+               Objects.equals(prioritizedFields, record.prioritizedFields);
     }
 
     @JacocoGenerated
     @Override
     public int hashCode() {
         return Objects.hash(getEntityDescription(), getCustomer(), getId(), getDoi(), getType(),
-                            getPublisherAuthority(), getRightsholder(), getSpatialCoverage(), getPartOf(), getPart(),
-                            getPublication(), getContentBundle(), getPublishedDate(), getCristinId(),
-                            getBrageLocation(), getPrioritizedProperties(),
-                            getErrors(), getWarnings(), getLink(), getSubjects(), getSubjectCode(), getAccessCode(),
-                            getProjects());
+                            getPublisherAuthority(),
+                            getRightsholder(), getSpatialCoverage(), getPartOf(), getPart(), getPublication(),
+                            getContentBundle(), getPublishedDate(), getCristinId(), getInsperaIdentifier(),
+                            getWiseflowIdentifier(), getBrageLocation(), getErrors(), getWarnings(), getLink(),
+                            getSubjects(), getSubjectCode(), getAccessCode(), getProjects(), prioritizedFields);
     }
 
     @JsonProperty("projects")
@@ -108,6 +111,24 @@ public class Record {
 
     public void setProjects(List<Project> projects) {
         this.projects = projects;
+    }
+
+    @JsonProperty("insperaIdentifier")
+    public String getInsperaIdentifier() {
+        return insperaIdentifier;
+    }
+
+    @JsonProperty("wiseflowIdentifier")
+    public String getWiseflowIdentifier() {
+        return wiseflowIdentifier;
+    }
+
+    public void setInsperaIdentifier(String insperaIdentifier) {
+        this.insperaIdentifier = insperaIdentifier;
+    }
+
+    public void setWiseflowIdentifier(String wiseflowIdentifier) {
+        this.wiseflowIdentifier = wiseflowIdentifier;
     }
 
     @JsonProperty("subjectCode")

--- a/src/main/java/no/sikt/nva/BrageProcessor.java
+++ b/src/main/java/no/sikt/nva/BrageProcessor.java
@@ -135,9 +135,13 @@ public class BrageProcessor implements Runnable {
 
     private Record injectContentBundle(Record record, File entryDirectory, BrageLocation brageLocation,
                                        DublinCore dublinCore) throws ContentException {
-        var embargo = DublinCoreScraper.extractEmbargo(dublinCore);
+        var embargo = extractEmbargo(dublinCore);
         record.setContentBundle(getContent(entryDirectory, brageLocation, dublinCore, embargo));
         return record;
+    }
+
+    private String extractEmbargo(DublinCore dublinCore) {
+        return DublinCoreScraper.extractEmbargo(dublinCore, customer);
     }
 
     private ResourceContent getContent(File entryDirectory, BrageLocation brageLocation, DublinCore dublinCore,

--- a/src/main/java/no/sikt/nva/BrageProcessor.java
+++ b/src/main/java/no/sikt/nva/BrageProcessor.java
@@ -135,13 +135,9 @@ public class BrageProcessor implements Runnable {
 
     private Record injectContentBundle(Record record, File entryDirectory, BrageLocation brageLocation,
                                        DublinCore dublinCore) throws ContentException {
-        var embargo = extractEmbargo(dublinCore);
+        var embargo = DublinCoreScraper.extractEmbargo(dublinCore);
         record.setContentBundle(getContent(entryDirectory, brageLocation, dublinCore, embargo));
         return record;
-    }
-
-    private String extractEmbargo(DublinCore dublinCore) {
-        return DublinCoreScraper.extractEmbargo(dublinCore, customer);
     }
 
     private ResourceContent getContent(File entryDirectory, BrageLocation brageLocation, DublinCore dublinCore,

--- a/src/main/java/no/sikt/nva/model/dublincore/DcValue.java
+++ b/src/main/java/no/sikt/nva/model/dublincore/DcValue.java
@@ -14,6 +14,8 @@ public class DcValue {
 
     public static final String XML_PREFIX = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>";
     private static final String DOI_PREFIX = "10.";
+    public static final String INSPERA = "inspera";
+    public static final String WISEFLOW = "wiseflow";
     @XmlAttribute
     private Element element;
 
@@ -343,6 +345,14 @@ public class DcValue {
     public boolean isEmbargoEndDate() {
         return Element.DATE.equals(this.element) && Qualifier.EMBARGO_DATE.equals(this.qualifier)
             || Element.DATE.equals(this.element) && Qualifier.EMBARGO_DATE_V2.equals(this.qualifier);
+    }
+
+    public boolean isInsperaIdentifier() {
+        return Element.IDENTIFIER.equals(this.element) && this.value.contains(INSPERA);
+    }
+
+    public boolean isaWiseflowIdentifier() {
+        return Element.IDENTIFIER.equals(this.element) && this.value.contains(WISEFLOW);
     }
 
     public String toXmlString() {

--- a/src/main/java/no/sikt/nva/scrapers/DublinCoreScraper.java
+++ b/src/main/java/no/sikt/nva/scrapers/DublinCoreScraper.java
@@ -309,7 +309,11 @@ public class DublinCoreScraper {
                                                                                   + issn.substring(4) : issn;
     }
 
-    public static String extractEmbargo(DublinCore dublinCore) {
+    public static String extractEmbargo(DublinCore dublinCore, String customer) {
+        return UIO.equals(customer) ? extractEmbargo(dublinCore) : null;
+    }
+
+    private static String extractEmbargo(DublinCore dublinCore) {
         return dublinCore
                    .getDcValues()
                    .stream()

--- a/src/main/java/no/sikt/nva/scrapers/DublinCoreScraper.java
+++ b/src/main/java/no/sikt/nva/scrapers/DublinCoreScraper.java
@@ -338,6 +338,24 @@ public class DublinCoreScraper {
                    .orElse(null);
     }
 
+    public static String extractInsperaIdentifier(DublinCore dublinCore) {
+        return dublinCore.getDcValues()
+                   .stream()
+                   .filter(DcValue::isInsperaIdentifier)
+                   .map(DcValue::scrapeValueAndSetToScraped)
+                   .findAny()
+                   .orElse(null);
+    }
+
+    public static String extractWiseflowIdentifier(DublinCore dublinCore) {
+        return dublinCore.getDcValues()
+                   .stream()
+                   .filter(DcValue::isaWiseflowIdentifier)
+                   .map(DcValue::scrapeValueAndSetToScraped)
+                   .findAny()
+                   .orElse(null);
+    }
+
     public static Type mapOriginTypeToNvaType(Set<String> types, DublinCore dublinCore, String customer) {
         var uniqueTypes = translateTypesInNorwegian(types);
         var type = new Type(types, TypeMapper.convertBrageTypeToNvaType(uniqueTypes));
@@ -801,6 +819,8 @@ public class DublinCoreScraper {
         record.setAccessCode(extractAccessCode(dublinCore));
         record.setProjects(extractProjects(dublinCore, fundingSources));
         record.setPrioritizedProperties(determinePrioritizedProperties(dublinCore, customer));
+        record.setInsperaIdentifier(extractInsperaIdentifier(dublinCore));
+        record.setWiseflowIdentifier(extractWiseflowIdentifier(dublinCore));
         return record;
     }
 

--- a/src/main/java/no/sikt/nva/scrapers/DublinCoreScraper.java
+++ b/src/main/java/no/sikt/nva/scrapers/DublinCoreScraper.java
@@ -313,7 +313,7 @@ public class DublinCoreScraper {
         return UIO.equals(customer) ? extractEmbargo(dublinCore) : null;
     }
 
-    private static String extractEmbargo(DublinCore dublinCore) {
+    public static String extractEmbargo(DublinCore dublinCore) {
         return dublinCore
                    .getDcValues()
                    .stream()

--- a/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
@@ -1407,6 +1407,25 @@ public class DublinCoreScraperTest {
         assertThat(record.getErrors().toString(), containsString(Error.UNKNOWN_PROJECT.name()));
     }
 
+    @Test
+    void shouldScrapeWiseflowAndInsperaIdentifiers(){
+        var insperaIdentifier = "no.ntnu:inspera:22222:22222";
+        var wiseFlowIdentifier = "no.usn:wiseflow:11111:11111";
+        var dcValues = List.of(
+            toDcType("Journal article"),
+            new DcValue(Element.IDENTIFIER, null, insperaIdentifier),
+            new DcValue(Element.IDENTIFIER, null, wiseFlowIdentifier),
+            new DcValue(Element.IDENTIFIER, Qualifier.DOI, "https://doi.org/10.1016/j.scitotenv.2021.151958"),
+            new DcValue(Element.IDENTIFIER, Qualifier.ISSN, "2038-324X"),
+            new DcValue(Element.IDENTIFIER, Qualifier.CITATION, randomString())
+        );
+        var dublinCore = DublinCoreFactory.createDublinCoreWithDcValues(dcValues);
+        var record = dcScraper.validateAndParseDublinCore(dublinCore, new BrageLocation(null), SOME_CUSTOMER);
+
+        assertThat(record.getInsperaIdentifier(), is(equalTo(insperaIdentifier)));
+        assertThat(record.getWiseflowIdentifier(), is(equalTo(wiseFlowIdentifier)));
+    }
+
     @DisplayName("When brage record has type Book, Textbook or Book of abstract, and " +
                  "publication has partOfSeries field which is present, looking up for series name" +
                  "in channel register csv file and if we get a match we are setting series pid in publication context")

--- a/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
@@ -1160,12 +1160,21 @@ public class DublinCoreScraperTest {
     }
 
     @Test
-    void shouldExtractEmbargo() {
+    void shouldExtractEmbargoWhenCustomerIsUio() {
         var embargoDate = "2024-08-26";
         var dcValue = new DcValue(Element.DATE, Qualifier.fromValue("embargoEndDate"), embargoDate);
         var dublinCore = DublinCoreFactory.createDublinCoreWithDcValues(List.of(dcValue));
-        var embargo = DublinCoreScraper.extractEmbargo(dublinCore);
+        var embargo = DublinCoreScraper.extractEmbargo(dublinCore, CustomerMapper.UIO);
         assertThat(embargo, is(equalTo(embargoDate)));
+    }
+
+    @Test
+    void shouldNotExtractEmbargoWhenCustomerIsNotUio() {
+        var embargoDate = "2024-08-26";
+        var dcValue = new DcValue(Element.DATE, Qualifier.fromValue("embargoEndDate"), embargoDate);
+        var dublinCore = DublinCoreFactory.createDublinCoreWithDcValues(List.of(dcValue));
+        var embargo = DublinCoreScraper.extractEmbargo(dublinCore, CustomerMapper.NTNU);
+        assertThat(embargo, is(nullValue()));
     }
 
     @Test
@@ -1179,7 +1188,7 @@ public class DublinCoreScraperTest {
         var dublinCore = DublinCoreFactory.createDublinCoreWithDcValues(List.of(dcValueInvalidEmbargoDate,
                                                                                 dcValueEmbargoDate,
                                                                                 dvValueEmbargoMostRecent));
-        var embargo = DublinCoreScraper.extractEmbargo(dublinCore);
+        var embargo = DublinCoreScraper.extractEmbargo(dublinCore, "uio");
         assertThat(embargo, is(equalTo(embargoDateMostRecent)));
     }
 


### PR DESCRIPTION
Have accidentally pushed not relevant commit for this brach, but I think it is ok, it is a one liner + test:

- Scraping wiseflow identifier
- Scraping inspera identifier
- Removing scraping of embargoEndDate from xml for all customer except UiO. Embargo from xml applies on all files for publication, it is unwanted. All customer except UiO will supply a FileEmbargo.txt files with all files that should have embargoes. (It is only UiT, UiO and FFI - external instances that have been using this embargo field in xml)