### PR TITLE
attempting to scrape fields from isPartOf and isPartOfSeries fields

### DIFF
--- a/src/main/java/no/sikt/nva/channelregister/ChannelRegister.java
+++ b/src/main/java/no/sikt/nva/channelregister/ChannelRegister.java
@@ -60,7 +60,8 @@ public final class ChannelRegister {
                                                                              NvaType.REPORT,
                                                                              NvaType.BOOK,
                                                                              NvaType.BOOK_OF_ABSTRACTS,
-                                                                             NvaType.TEXTBOOK);
+                                                                             NvaType.TEXTBOOK,
+                                                                             NvaType.WORKING_PAPER);
     public final static List<NvaType> SEARCHABLE_TYPES_IN_PUBLISHERS = List.of(
         NvaType.BOOK, NvaType.DATASET, NvaType.REPORT, NvaType.BACHELOR_THESIS, NvaType.MASTER_THESIS,
         NvaType.DOCTORAL_THESIS, NvaType.WORKING_PAPER, NvaType.STUDENT_PAPER, NvaType.STUDENT_PAPER_OTHERS,
@@ -249,12 +250,8 @@ public final class ChannelRegister {
             if (StringUtils.isBlank(title)) {
                 return title;
             } else {
-                var channel = channelRegisterJournals.stream()
-                                  .filter(item -> item.hasTitle(title))
-                                  .map(ChannelRegisterJournal::getPid)
-                                  .distinct()
-                                  .collect(SingletonCollector.collectOrElse(null));
-                return Optional.ofNullable(channel).orElseGet(() -> lookupInJournalAliases(title));
+                return Optional.ofNullable(lookUpInJournalsByTitle(title))
+                           .orElseGet(() -> lookupInJournalAliases(title));
             }
         } catch (IllegalStateException e) {
             logger.error(new ErrorDetails(DUPLICATE_JOURNAL_IN_CHANNEL_REGISTER,
@@ -265,6 +262,14 @@ public final class ChannelRegister {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    private String lookUpInJournalsByTitle(String title) {
+        return channelRegisterJournals.stream()
+                   .filter(item -> item.hasTitle(title))
+                   .map(ChannelRegisterJournal::getPid)
+                   .distinct()
+                   .collect(SingletonCollector.collectOrElse(null));
     }
 
     public String lookUpInPublisher(String publisher, String customer) {
@@ -414,11 +419,7 @@ public final class ChannelRegister {
                    .map(ChannelRegisterAlias::getOriginalTitle)
                    .distinct()
                    .collect(SingletonCollector.collectOrElse(null));
-        return channelRegisterJournals.stream()
-                   .filter(item -> item.hasTitle(originalTitle))
-                   .map(ChannelRegisterJournal::getPid)
-                   .distinct()
-                   .collect(SingletonCollector.collectOrElse(null));
+        return lookUpInJournalsByTitle(originalTitle);
     }
 
     private String lookupInPublisherAliases(List<ChannelRegisterPublisher> publishers, List<ChannelRegisterAlias> aliases, String publisher) {

--- a/src/main/java/no/sikt/nva/scrapers/DublinCoreScraper.java
+++ b/src/main/java/no/sikt/nva/scrapers/DublinCoreScraper.java
@@ -697,18 +697,21 @@ public class DublinCoreScraper {
     }
 
     private static PartOfSeries constructPartOfSeries(List<String> list, DublinCore dublinCore) {
-        var name = attempt(() -> list.get(0)).orElse(failure -> null);
-        var number = Optional.ofNullable(attempt(() -> list.get(1)).orElse(failure -> null))
+        var firstEntry = attempt(() -> list.get(0)).orElse(failure -> null);
+        var secondEntry = Optional.ofNullable(attempt(() -> list.get(1)).orElse(failure -> null))
                          .or(() -> Optional.ofNullable(extractPartOf(dublinCore)))
                          .orElse(null);
-        return isSeriesName(name)
-                   ? new PartOfSeries(name, number)
-                   : new PartOfSeries(number, name);
+        return extractSeries(firstEntry, secondEntry);
+    }
+
+    private static PartOfSeries extractSeries(String firstEntry, String secondEntry) {
+        return isSeriesName(firstEntry)
+                   ? new PartOfSeries(firstEntry, secondEntry)
+                   : new PartOfSeries(secondEntry, firstEntry);
     }
 
     private static boolean isSeriesName(String value) {
-        // Assuming series names are non-null and not in the format of a series number
-        return value != null && !value.matches("\\d{4}\\W\\d{2}") && !value.matches("\\d+");
+        return StringUtils.isNotBlank(value) && !value.matches("\\d{4}\\W\\d{2}") && !value.matches("\\d+");
     }
 
     private static String extractPartOf(DublinCore dublinCore) {

--- a/src/main/java/no/sikt/nva/scrapers/DublinCoreScraper.java
+++ b/src/main/java/no/sikt/nva/scrapers/DublinCoreScraper.java
@@ -681,25 +681,34 @@ public class DublinCoreScraper {
                                      .filter(DcValue::isPartOfSeries)
                                      .map(DcValue::scrapeValueAndSetToScraped)
                                      .collect(Collectors.toList());
-       return convertListToPartOfSeries(partOfSeriesValues);
+       return convertListToPartOfSeries(partOfSeriesValues, dublinCore);
     }
 
-    private static PartOfSeries convertListToPartOfSeries(List<String> list) {
+    private static PartOfSeries convertListToPartOfSeries(List<String> list, DublinCore dublinCore) {
         if (isSingleton(list)) {
             var parts = Arrays.stream(list.get(0).split(";"))
                             .map(String::trim)
                             .filter(value -> !value.isEmpty())
                             .collect(Collectors.toList());
-            return constructPartOfSeries(parts);
+            return constructPartOfSeries(parts, dublinCore);
         } else {
-            return constructPartOfSeries(list);
+            return constructPartOfSeries(list, dublinCore);
         }
     }
 
-    private static PartOfSeries constructPartOfSeries(List<String> list) {
+    private static PartOfSeries constructPartOfSeries(List<String> list, DublinCore dublinCore) {
         var name = attempt(() -> list.get(0)).orElse(failure -> null);
-        var number = attempt(() -> list.get(1)).orElse(failure -> null);
-        return new PartOfSeries(name, number);
+        var number = Optional.ofNullable(attempt(() -> list.get(1)).orElse(failure -> null))
+                         .or(() -> Optional.ofNullable(extractPartOf(dublinCore)))
+                         .orElse(null);
+        return isSeriesName(name)
+                   ? new PartOfSeries(name, number)
+                   : new PartOfSeries(number, name);
+    }
+
+    private static boolean isSeriesName(String value) {
+        // Assuming series names are non-null and not in the format of a series number
+        return value != null && !value.matches("\\d{4}\\W\\d{2}") && !value.matches("\\d+");
     }
 
     private static String extractPartOf(DublinCore dublinCore) {
@@ -907,11 +916,12 @@ public class DublinCoreScraper {
     private void setIdFromJournals(BrageLocation brageLocation, Record record) {
         if (isReport(record)) {
             setChannelRegisterIdentifierForReport(brageLocation, record);
+            return;
         }
         if (isJournal(record)) {
             setChannelRegisterIdentifierForJournal(brageLocation, record);
         }
-        if (isBook(record)) {
+        if (hasPartOfSeries(record)) {
             setChannelRegisterIdentifierForBook(brageLocation, record);
         }
     }
@@ -936,11 +946,8 @@ public class DublinCoreScraper {
                    .isPresent();
     }
 
-    private boolean isBook(Record record) {
-        var type = record.getType().getNva();
-        return NvaType.BOOK.getValue().equals(type)
-               || NvaType.TEXTBOOK.getValue().equals(type)
-               || NvaType.BOOK_OF_ABSTRACTS.getValue().equals(type);
+    private boolean hasPartOfSeries(Record record) {
+        return nonNull(record.getPublication().getPartOfSeries());
     }
 
     private void setChannelRegisterIdentifierForJournal(BrageLocation brageLocation, Record record) {

--- a/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
@@ -46,6 +46,8 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
@@ -1421,7 +1423,7 @@ public class DublinCoreScraperTest {
                  "in channel register csv file and if we get a match we are setting series pid in publication context")
     @ParameterizedTest
     @ValueSource(strings = {"Book", "Textbook", "Book of abstracts"})
-    void shouldLookUpSeriesInChannelRegisterWhenPublicationIsBookWithPartOfSeries(String type){
+    void shouldLookUpSeriesInChannelRegisterWhenPublicationHasPartOfSeriesWithPartOfSeries(String type){
         var dcValues = List.of(
             toDcType(type),
             new DcValue(Element.RELATION, Qualifier.IS_PART_OF_SERIES, "The Bryggen Papers;9")
@@ -1431,6 +1433,24 @@ public class DublinCoreScraperTest {
 
         assertThat(record.getPublication().getPublicationContext().getSeries().getPid(),
                    is(equalTo("5FCE7321-320B-4EB6-B890-A2AD85B1BFC1")));
+    }
+
+    @Test
+    void shouldConvertPartOfAndPartOfSeriesFieldsToPartOfSeriesAndLookUpForSeriesInChannelRegister() {
+        var seriesName = "Cicero Working papers";
+        var seriesNumber = "2010:03";
+        var dcValues = List.of(
+            toDcType("Working paper"),
+            new DcValue(Element.RELATION, Qualifier.IS_PART_OF, seriesName),
+            new DcValue(Element.RELATION, Qualifier.IS_PART_OF_SERIES, seriesNumber)
+        );
+        var dublinCore = DublinCoreFactory.createDublinCoreWithDcValues(dcValues);
+        var record = dcScraper.validateAndParseDublinCore(dublinCore, new BrageLocation(null), SOME_CUSTOMER);
+
+        var expectedPartOfSeries = new PartOfSeries(seriesName, seriesNumber);
+
+        assertNotNull(record.getPublication().getPublicationContext().getSeries().getPid());
+        assertTrue(record.getPublication().getPartOfSeries().equals(expectedPartOfSeries));
     }
 
     private static DcValue toDcType(String t) {

--- a/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
@@ -132,6 +132,11 @@ public class DublinCoreScraperTest {
         );
     }
 
+    public static Stream<Arguments> seriesSupplier() {
+        return Stream.of(Arguments.of("Cicero Working papers", "2010:03"),
+                         Arguments.of("2010:03", "Cicero Working papers"));
+    }
+
     private static DcValue partOfSeries(String value) {
         return new DcValue(Element.RELATION, Qualifier.IS_PART_OF_SERIES, value);
     }
@@ -1435,14 +1440,16 @@ public class DublinCoreScraperTest {
                    is(equalTo("5FCE7321-320B-4EB6-B890-A2AD85B1BFC1")));
     }
 
-    @Test
-    void shouldConvertPartOfAndPartOfSeriesFieldsToPartOfSeriesAndLookUpForSeriesInChannelRegister() {
+    @ParameterizedTest
+    @MethodSource("seriesSupplier")
+    void shouldConvertPartOfAndPartOfSeriesFieldsToPartOfSeriesAndLookUpForSeriesInChannelRegister(String firstValue,
+                                                                                                   String secondValue) {
         var seriesName = "Cicero Working papers";
         var seriesNumber = "2010:03";
         var dcValues = List.of(
             toDcType("Working paper"),
-            new DcValue(Element.RELATION, Qualifier.IS_PART_OF, seriesName),
-            new DcValue(Element.RELATION, Qualifier.IS_PART_OF_SERIES, seriesNumber)
+            new DcValue(Element.RELATION, Qualifier.IS_PART_OF, firstValue),
+            new DcValue(Element.RELATION, Qualifier.IS_PART_OF_SERIES, secondValue)
         );
         var dublinCore = DublinCoreFactory.createDublinCoreWithDcValues(dcValues);
         var record = dcScraper.validateAndParseDublinCore(dublinCore, new BrageLocation(null), SOME_CUSTOMER);


### PR DESCRIPTION
We found another way institutions have added series publication channel in Brage. Most institutions did it by using isPartOfSeries field, or multiple isPartOfSeries fields. Cicero have used isPartOf field for series name, and isPartOfSeries for series number, in addition to "standard" way of doing it. Adding support for it, will test by running multiple imports. 