### PR TITLE
map subjects for ffi

### DIFF
--- a/src/main/java/no/sikt/nva/scrapers/SubjectScraper.java
+++ b/src/main/java/no/sikt/nva/scrapers/SubjectScraper.java
@@ -10,6 +10,7 @@ import no.sikt.nva.model.dublincore.DcValue;
 import no.sikt.nva.model.dublincore.DublinCore;
 import no.sikt.nva.model.dublincore.Qualifier;
 import nva.commons.core.JacocoGenerated;
+import nva.commons.core.StringUtils;
 
 public final class SubjectScraper {
 
@@ -37,6 +38,7 @@ public final class SubjectScraper {
                    .filter(SubjectScraper::isSubjectAndNotSpecificallyIgnored)
                    .map(DcValue::scrapeValueAndSetToScraped)
                    .filter(Objects::nonNull)
+                   .map(value -> value.replace("TermSet Emneord::", StringUtils.EMPTY_STRING))
                    .distinct()
                    .collect(Collectors.toList());
     }

--- a/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
+++ b/src/test/java/no/sikt/nva/scrapers/DublinCoreScraperTest.java
@@ -489,6 +489,20 @@ public class DublinCoreScraperTest {
     }
 
     @Test
+    void shouldScrapeSubjectAndRemoveTermsetEmneordFromItsValue() {
+        var value = "TermSet Emneord::Kommunikasjon";
+        var normalTagWithQualifierNone = new DcValue(Element.SUBJECT, null, value);
+        var dublinCore = DublinCoreFactory.createDublinCoreWithDcValues(
+            List.of(normalTagWithQualifierNone, toDcType("Journal Article")));
+        var record = dcScraper.validateAndParseDublinCore(dublinCore, new BrageLocation(null), SOME_CUSTOMER);
+
+        var expectedTag = "Kommunikasjon";
+
+        assertEquals(expectedTag, record.getEntityDescription().getTags().get(0));
+    }
+
+
+    @Test
     void shouldScrapeUnrecognizedSubjectsAndWarnAboutUnrecognizedSubject() {
         var tag = randomString();
         var typeDcValue = toDcType("Journal Article");


### PR DESCRIPTION
Removing "TermSet Emneord::" string fro subject values. FFI has this string in almost all subjects. 